### PR TITLE
fix: keep preset when AUTO turns real device off

### DIFF
--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -396,9 +396,12 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
 
         # Detect when the real device's temperature setpoint was changed
         # externally (e.g., via a physical remote) and exit preset mode.
+        # Skip when the real device is OFF: turning it off when the room is
+        # comfortable is normal AUTO operation, not an external change.
         if (
             self._hvac_mode == HVACMode.AUTO
             and self._preset_mode != PRESET_NONE
+            and state.state != HVACMode.OFF.value
         ):
             real_target = state.attributes.get("temperature")
             if real_target is not None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -664,6 +664,23 @@ class TestStateCallbacks:
         entity._on_real_climate_update()
         assert entity._preset_mode == PRESET_HOME
 
+    def test_real_device_off_does_not_exit_preset(self):
+        """Real device transitioning to OFF (normal AUTO comfort-band behavior)
+        must not trigger external-change detection and clear the preset."""
+        entity, hass = self._entity_with_sensors()
+        entity._last_real_mode = HVACMode.COOL
+        expected = entity._expected_real_target()
+        state = MagicMock()
+        state.state = HVACMode.OFF.value
+        state.attributes = {
+            "hvac_action": HVACAction.OFF.value,
+            # Stale/mismatched setpoint that WOULD cross the 0.5 threshold
+            "temperature": expected + 5.0,
+        }
+        hass.states.get = lambda eid: state if eid == REAL_CLIMATE_ID else MagicMock()
+        entity._on_real_climate_update()
+        assert entity._preset_mode == PRESET_HOME
+
 
 # ---------------------------------------------------------------------------
 # Unit tests – expected real target & mode-appropriate setpoints


### PR DESCRIPTION
## Summary

Fixes #40.

When smart climate is in AUTO mode with a preset, `_async_sync_real_climate` correctly turns the real device OFF once the room reaches the comfort band. The resulting state-change event caused `_on_real_climate_update` to treat the OFF transition as an external setpoint change (because `_updating_from_control` was False on the sensor-triggered path and `_last_real_mode` was not updated on OFF), clearing the preset to `none`.

- Skip external-change detection in `_on_real_climate_update` when the real device reports `state == HVACMode.OFF`. An OFF state carries no meaningful setpoint to compare against.
- Added `test_real_device_off_does_not_exit_preset` regression test that forces a stale expected target well beyond the 0.5C threshold and verifies the preset is preserved.

## Test plan

- [x] `pytest tests/test_climate.py` — 78 passed
- [x] New regression test passes and fails without the one-line guard
- [x] Existing `test_external_real_temperature_change_exits_preset` still passes (physical-remote override path unaffected)