### PR TITLE
refactor!: make real climate a pure slave of smart climate

### DIFF
--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -89,6 +89,12 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
       - Sleep – cooler nighttime comfort range
       - Away  – wider range for unoccupied periods
       - None  – manual/direct control (no preset enforced)
+
+    Master/slave relationship with the real climate entity:
+    This entity is the sole writer of the wrapped device's hvac_mode and
+    temperature.  State-change events from the real device are used only to
+    mirror its hvac_action for UI display – they never feed back into the
+    authoritative state owned here (hvac_mode, preset_mode, setpoints).
     """
 
     _attr_has_entity_name = True
@@ -139,14 +145,9 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         self._outside_temperature: float | None = None
         self._hvac_action: HVACAction | None = None
 
-        # Guard flags – prevent feedback loops between control calls and state
-        # changes arriving from the real climate / sensors.
+        # Guard flag – skip sensor-triggered syncs while a control call is in
+        # flight so the two paths do not issue overlapping service calls.
         self._updating_from_control: bool = False
-        self._updating_from_real: bool = False
-
-        # Tracks the last HEAT/COOL mode sent to the real device; used by
-        # _desired_real_mode to apply hysteresis and avoid rapid cycling.
-        self._last_real_mode: HVACMode | None = None
 
         # Timestamp at which the inside temperature first entered the
         # comfortable mid-band zone (between low+deadband and high-deadband).
@@ -288,11 +289,7 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         if self._hvac_mode != HVACMode.OFF:
             await self._async_sync_real_climate()
 
-        # Subscribe to state changes on all tracked entities.  This is done
-        # *after* the initial sync so that stale state-change events from the
-        # real climate device (whose setpoint may not yet match the restored
-        # preset) do not trigger false "external change" detection and reset
-        # the preset to NONE.
+        # Subscribe to state changes on all tracked entities.
         entities_to_track = [self._real_climate_id, self._inside_sensor_id]
         if self._outside_sensor_id:
             entities_to_track.append(self._outside_sensor_id)
@@ -332,14 +329,6 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             except ValueError:
                 pass
 
-        # Seed _last_real_mode so hysteresis works correctly from the first update
-        try:
-            current_mode = HVACMode(state.state)
-            if current_mode in (HVACMode.HEAT, HVACMode.COOL):
-                self._last_real_mode = current_mode
-        except ValueError:
-            pass
-
     def _sync_from_sensors(self) -> None:
         """Pull current temperatures from the sensor entities at startup."""
         inside_state = self.hass.states.get(self._inside_sensor_id)
@@ -371,55 +360,29 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
 
     @callback
     def _on_real_climate_update(self) -> None:
-        """Handle state change of the wrapped climate device."""
-        if self._updating_from_control:
-            return
+        """Mirror the real device's hvac_action for UI display.
 
-        self._updating_from_real = True
-        needs_write = False
-
+        Smart climate is the authoritative source of truth for mode, preset,
+        and setpoints – see the master/slave note at the top of this class.
+        Real-device state-change events are used only to surface the current
+        action (heating / cooling / idle / off) in the frontend.
+        """
         state = self.hass.states.get(self._real_climate_id)
         if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-            self._updating_from_real = False
             return
 
-        # Mirror the HVAC action (heating / cooling / idle / off …)
         action_str = state.attributes.get("hvac_action")
-        if action_str:
-            try:
-                new_action = HVACAction(action_str)
-                if self._hvac_action != new_action:
-                    self._hvac_action = new_action
-                    needs_write = True
-            except ValueError:
-                pass
+        if not action_str:
+            return
 
-        # Detect when the real device's temperature setpoint was changed
-        # externally (e.g., via a physical remote) and exit preset mode.
-        # Skip when the real device is OFF: turning it off when the room is
-        # comfortable is normal AUTO operation, not an external change.
-        if (
-            self._hvac_mode == HVACMode.AUTO
-            and self._preset_mode != PRESET_NONE
-            and state.state != HVACMode.OFF.value
-        ):
-            real_target = state.attributes.get("temperature")
-            if real_target is not None:
-                expected = self._expected_real_target()
-                if abs(float(real_target) - expected) > 0.5:
-                    _LOGGER.debug(
-                        "Real climate setpoint changed externally "
-                        "(expected %.1f, got %.1f) – switching to manual",
-                        expected,
-                        float(real_target),
-                    )
-                    self._preset_mode = PRESET_NONE
-                    needs_write = True
+        try:
+            new_action = HVACAction(action_str)
+        except ValueError:
+            return
 
-        if needs_write:
+        if self._hvac_action != new_action:
+            self._hvac_action = new_action
             self.async_write_ha_state()
-
-        self._updating_from_real = False
 
     @callback
     def _on_inside_sensor_update(self) -> None:
@@ -559,37 +522,12 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
     # Real-climate synchronisation
     # ------------------------------------------------------------------
 
-    def _expected_real_target(self) -> float:
-        """Return the temperature the real device should currently be set to.
-
-        In AUTO mode the target depends on whether we are heating or cooling:
-        HEAT targets low + INSIDE_DEADBAND so the real device's own internal
-        deadband causes it to start heating at approximately the configured low
-        setpoint.  COOL targets one below the high setpoint (high - 1) to
-        prevent real devices that only accept integer setpoints from
-        overshooting to high + 0.5 due to their own internal hysteresis.
-        The result is capped at low so it never falls below the heating target
-        for very narrow bands.
-        """
-        if self._hvac_mode != HVACMode.AUTO:
-            return self._target_temperature
-        low, high = self._active_range()
-        if self._last_real_mode == HVACMode.HEAT:
-            return low + INSIDE_DEADBAND
-        if self._last_real_mode == HVACMode.COOL:
-            return max(low, high - 1)
-        return self._preset_midpoint()
-
     async def _async_sync_real_climate(self) -> None:
         """Push the desired mode and setpoint to the real climate device."""
-        if self._updating_from_real or self._updating_from_control:
+        if self._updating_from_control:
             return
 
         real_mode = self._desired_real_mode()
-        # Track the decided HEAT/COOL mode so _expected_real_target can
-        # report what the device should be set to for external-change detection.
-        if real_mode in (HVACMode.HEAT, HVACMode.COOL):
-            self._last_real_mode = real_mode
 
         real_state = self.hass.states.get(self._real_climate_id)
         if real_state is None:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -204,7 +204,7 @@ class TestDesiredRealMode:
 class TestDesiredRealModeHysteresis:
     """Tests for the band-boundary and OFF behaviour in _desired_real_mode."""
 
-    def _entity(self, inside: float, last_mode: HVACMode | None = None, outside: float | None = None):
+    def _entity(self, inside: float, outside: float | None = None):
         hass = _make_hass_mock(inside_temp=inside, outside_temp=outside)
         config = {
             CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
@@ -217,47 +217,34 @@ class TestDesiredRealModeHysteresis:
         entity._preset_mode = PRESET_HOME
         entity._current_temperature = inside
         entity._outside_temperature = outside
-        entity._last_real_mode = last_mode
         return entity
 
-    def test_in_range_last_heat_returns_off(self):
-        """When inside is within the comfort band, return OFF regardless of last mode."""
+    def test_in_range_returns_off(self):
+        """When inside is within the comfort band, return OFF."""
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, last_mode=HVACMode.HEAT)
+        entity = self._entity(inside=mid)
         assert entity._desired_real_mode() == HVACMode.OFF
 
-    def test_in_range_last_cool_returns_off(self):
-        """When inside is within the comfort band, return OFF regardless of last mode."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, last_mode=HVACMode.COOL)
-        assert entity._desired_real_mode() == HVACMode.OFF
-
-    def test_in_range_no_prior_mode_returns_off(self):
-        """No prior mode and in-band temperature → OFF."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, last_mode=None)
-        assert entity._desired_real_mode() == HVACMode.OFF
-
-    def test_below_low_plus_deadband_heats_regardless_of_last_mode(self):
-        """At low + deadband (HEAT boundary) → always HEAT regardless of prior mode."""
-        entity = self._entity(inside=DEFAULT_HOME_MIN + INSIDE_DEADBAND, last_mode=HVACMode.COOL)
+    def test_below_low_plus_deadband_heats(self):
+        """At low + deadband (HEAT boundary) → HEAT."""
+        entity = self._entity(inside=DEFAULT_HOME_MIN + INSIDE_DEADBAND)
         assert entity._desired_real_mode() == HVACMode.HEAT
 
-    def test_below_low_always_heats_regardless_of_last_mode(self):
-        """Below low setpoint must always HEAT regardless of prior mode."""
-        entity = self._entity(inside=DEFAULT_HOME_MIN - 0.5, last_mode=HVACMode.COOL)
+    def test_below_low_heats(self):
+        """Below low setpoint → HEAT."""
+        entity = self._entity(inside=DEFAULT_HOME_MIN - 0.5)
         assert entity._desired_real_mode() == HVACMode.HEAT
 
-    def test_above_high_always_cools_regardless_of_last_mode(self):
-        """Above high setpoint must always COOL regardless of prior mode."""
-        entity = self._entity(inside=DEFAULT_HOME_MAX + 0.5, last_mode=HVACMode.HEAT)
+    def test_above_high_cools(self):
+        """Above high setpoint → COOL."""
+        entity = self._entity(inside=DEFAULT_HOME_MAX + 0.5)
         assert entity._desired_real_mode() == HVACMode.COOL
 
     def test_21_23_band_cools_at_22_5(self):
         """Issue regression: 21-23 band should switch to COOL at 22.5.
 
         high - INSIDE_DEADBAND = 23 - 0.5 = 22.5, so at 22.5 the system
-        should engage cooling even when last mode was HEAT.
+        should engage cooling.
         """
         hass = _make_hass_mock(inside_temp=22.5)
         config = {
@@ -270,7 +257,6 @@ class TestDesiredRealModeHysteresis:
         entity._target_temp_low = 21.0
         entity._target_temp_high = 23.0
         entity._current_temperature = 22.5
-        entity._last_real_mode = HVACMode.HEAT
         assert entity._desired_real_mode() == HVACMode.COOL
 
     def test_21_23_band_in_band_returns_off(self):
@@ -286,7 +272,6 @@ class TestDesiredRealModeHysteresis:
         entity._target_temp_low = 21.0
         entity._target_temp_high = 23.0
         entity._current_temperature = 22.4
-        entity._last_real_mode = HVACMode.HEAT
         assert entity._desired_real_mode() == HVACMode.OFF
 
     def test_21_23_band_heats_at_21_5(self):
@@ -309,11 +294,9 @@ class TestDesiredRealModeHysteresis:
         entity._current_temperature = 21.5
         assert entity._desired_real_mode() == HVACMode.HEAT
 
-    def test_at_high_minus_deadband_cools_regardless_of_last_heat(self):
-        """At high - deadband, COOL takes priority over prior HEAT."""
-        entity = self._entity(
-            inside=DEFAULT_HOME_MAX - INSIDE_DEADBAND, last_mode=HVACMode.HEAT
-        )
+    def test_at_high_minus_deadband_cools(self):
+        """At high - deadband (COOL boundary) → COOL."""
+        entity = self._entity(inside=DEFAULT_HOME_MAX - INSIDE_DEADBAND)
         assert entity._desired_real_mode() == HVACMode.COOL
 
 
@@ -633,61 +616,40 @@ class TestStateCallbacks:
         entity._on_real_climate_update()
         assert entity._hvac_action == HVACAction.HEATING
 
-    def test_external_real_temperature_change_exits_preset(self):
-        """When real device setpoint drifts far from expected target, go manual."""
-        entity, hass = self._entity_with_sensors()
-        # With last_real_mode=COOL the expected target is the high setpoint
-        entity._last_real_mode = HVACMode.COOL
-        expected = entity._expected_real_target()
-        state = MagicMock()
-        state.state = HVACMode.COOL.value
-        state.attributes = {
-            "hvac_action": HVACAction.COOLING.value,
-            "temperature": expected + 3.0,  # More than 0.5 away from expected
-        }
-        hass.states.get = lambda eid: state if eid == REAL_CLIMATE_ID else MagicMock()
-        entity._on_real_climate_update()
-        assert entity._preset_mode == PRESET_NONE
+    def test_real_setpoint_divergence_does_not_clear_preset(self):
+        """Master/slave: real-device state events never mutate preset_mode.
 
-    def test_external_change_stays_preset_when_target_matches(self):
-        """Real device at expected target should NOT exit preset mode."""
-        entity, hass = self._entity_with_sensors()
-        entity._last_real_mode = HVACMode.HEAT
-        expected = entity._expected_real_target()
-        state = MagicMock()
-        state.state = HVACMode.HEAT.value
-        state.attributes = {
-            "hvac_action": HVACAction.HEATING.value,
-            "temperature": expected,
-        }
-        hass.states.get = lambda eid: state if eid == REAL_CLIMATE_ID else MagicMock()
-        entity._on_real_climate_update()
-        assert entity._preset_mode == PRESET_HOME
-
-    def test_real_device_off_does_not_exit_preset(self):
-        """Real device transitioning to OFF (normal AUTO comfort-band behavior)
-        must not trigger external-change detection and clear the preset."""
-        entity, hass = self._entity_with_sensors()
-        entity._last_real_mode = HVACMode.COOL
-        expected = entity._expected_real_target()
-        state = MagicMock()
-        state.state = HVACMode.OFF.value
-        state.attributes = {
-            "hvac_action": HVACAction.OFF.value,
-            # Stale/mismatched setpoint that WOULD cross the 0.5 threshold
-            "temperature": expected + 5.0,
-        }
-        hass.states.get = lambda eid: state if eid == REAL_CLIMATE_ID else MagicMock()
-        entity._on_real_climate_update()
-        assert entity._preset_mode == PRESET_HOME
+        Smart climate is the sole writer of the real device's setpoint, so any
+        divergence reported back (in any hvac state, by any magnitude) must be
+        ignored by _on_real_climate_update.  This covers the whole class of
+        feedback-loop bugs where smart's own OFF / HEAT / COOL writes were
+        misread as external user overrides and wrongly dropped the preset.
+        """
+        for real_state, real_action, setpoint_offset in [
+            (HVACMode.OFF.value, HVACAction.OFF.value, 5.0),
+            (HVACMode.HEAT.value, HVACAction.HEATING.value, 10.0),
+            (HVACMode.COOL.value, HVACAction.COOLING.value, -10.0),
+        ]:
+            entity, hass = self._entity_with_sensors()
+            state = MagicMock()
+            state.state = real_state
+            state.attributes = {
+                "hvac_action": real_action,
+                "temperature": 22.0 + setpoint_offset,
+            }
+            hass.states.get = lambda eid, s=state: s if eid == REAL_CLIMATE_ID else MagicMock()
+            entity._on_real_climate_update()
+            assert entity._preset_mode == PRESET_HOME, (
+                f"preset wrongly cleared for real_state={real_state}"
+            )
 
 
 # ---------------------------------------------------------------------------
-# Unit tests – expected real target & mode-appropriate setpoints
+# Unit tests – mode-appropriate setpoints sent to the real device
 # ---------------------------------------------------------------------------
 
-class TestExpectedRealTarget:
-    """Tests for _expected_real_target – smooth temperature switching."""
+class TestSyncedSetpoints:
+    """Tests verifying _async_sync_real_climate sends the right setpoint."""
 
     def _entity(self, inside: float = 22.0, outside: float | None = None):
         hass = _make_hass_mock(inside_temp=inside, outside_temp=outside)
@@ -703,53 +665,6 @@ class TestExpectedRealTarget:
         entity._current_temperature = inside
         entity._outside_temperature = outside
         return entity
-
-    def test_heat_targets_low_setpoint(self):
-        """In AUTO+HEAT, real device should target low + INSIDE_DEADBAND."""
-        entity = self._entity()
-        entity._last_real_mode = HVACMode.HEAT
-        assert entity._expected_real_target() == DEFAULT_HOME_MIN + INSIDE_DEADBAND
-
-    def test_cool_targets_high_minus_one(self):
-        """In AUTO+COOL, real device should target high - 1 to avoid integer overshoot."""
-        entity = self._entity()
-        entity._last_real_mode = HVACMode.COOL
-        assert entity._expected_real_target() == DEFAULT_HOME_MAX - 1
-
-    def test_no_prior_mode_targets_midpoint(self):
-        """When no prior mode, fall back to midpoint."""
-        entity = self._entity()
-        entity._last_real_mode = None
-        expected_mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2.0
-        assert entity._expected_real_target() == pytest.approx(expected_mid)
-
-    def test_non_auto_mode_targets_single_setpoint(self):
-        """In HEAT/COOL single mode, target the stored single-point temp."""
-        entity = self._entity()
-        entity._hvac_mode = HVACMode.HEAT
-        entity._target_temperature = 23.0
-        assert entity._expected_real_target() == 23.0
-
-    def test_heat_to_cool_creates_dead_zone(self):
-        """Switching from HEAT to COOL jumps from low+deadband to high-1 target.
-
-        The gap between low+deadband and high-1 is the "dead zone" where the
-        real device is OFF and not actively heating or cooling.
-        Using high-1 (rather than high) prevents integer-only devices from
-        overshooting to high+0.5 and appearing to breach the upper band.
-        """
-        entity = self._entity()
-        entity._last_real_mode = HVACMode.HEAT
-        heat_target = entity._expected_real_target()
-
-        entity._last_real_mode = HVACMode.COOL
-        cool_target = entity._expected_real_target()
-
-        assert heat_target == DEFAULT_HOME_MIN + INSIDE_DEADBAND
-        assert cool_target == DEFAULT_HOME_MAX - 1
-        # Gap = (high - 1) - (low + deadband) = (high - low) - 1 - deadband
-        expected_gap = (DEFAULT_HOME_MAX - DEFAULT_HOME_MIN) - 1 - INSIDE_DEADBAND
-        assert cool_target - heat_target == expected_gap
 
     @pytest.mark.asyncio
     async def test_sync_sends_low_plus_deadband_when_heating(self):
@@ -854,15 +769,24 @@ class TestExpectedRealTarget:
         call_args = hass.services.async_call.call_args
         assert call_args[0][2]["temperature"] == high - 1  # 22, not 23
 
-    def test_cool_target_capped_at_low_for_narrow_band(self):
-        """Narrow band: cooling target must not drop below the low setpoint."""
-        entity = self._entity()
+    @pytest.mark.asyncio
+    async def test_sync_cool_target_capped_at_low_for_narrow_band(self):
+        """Narrow band: cooling target sent to real device must not drop below low."""
+        hass = _make_hass_mock(
+            real_climate_state=HVACMode.COOL.value,
+            real_climate_temp=None,
+            inside_temp=23.0,
+        )
+        entity = _make_entity(hass)
+        entity._hvac_mode = HVACMode.AUTO
         entity._preset_mode = PRESET_NONE
         entity._target_temp_low = 22.0
         entity._target_temp_high = 22.5  # only 0.5 °C wide
-        entity._last_real_mode = HVACMode.COOL
-        # high - 1 = 21.5 < low = 22.0, so result must be capped at low
-        assert entity._expected_real_target() == 22.0
+        entity._current_temperature = 23.0  # above high → COOL
+        await entity._async_sync_real_climate()
+        call_args = hass.services.async_call.call_args
+        # high - 1 = 21.5 < low = 22.0, so target must be capped at low
+        assert call_args[0][2]["temperature"] == 22.0
 
 
 # ---------------------------------------------------------------------------
@@ -1034,14 +958,14 @@ class TestStateRestoration:
         assert entity._preset_mode == PRESET_HOME
 
     @pytest.mark.asyncio
-    async def test_preset_not_reset_by_stale_real_device_temp(self):
-        """Preset must NOT be reset to NONE by a mismatched real device temp on startup.
+    async def test_preset_survives_mismatched_real_device_temp(self):
+        """Preset is restored verbatim regardless of real device's reported setpoint.
 
-        Before the fix, the real device's stale setpoint from before the
-        restart would trigger the external-change detection in
-        _on_real_climate_update, falsely resetting the preset to NONE.  By
-        subscribing to state changes *after* the initial sync, stale events
-        cannot fire during setup.
+        Smart climate owns preset_mode; real-device setpoint never feeds back
+        into it.  This test pins that contract end-to-end through startup:
+        even if the wrapped device reports a wildly divergent temperature
+        (e.g. stale value from before the restart), the restored preset is
+        unaffected.
         """
         last_state = self._make_last_state(
             hvac_mode=HVACMode.AUTO.value,
@@ -1049,50 +973,10 @@ class TestStateRestoration:
             target_temp_low=DEFAULT_SLEEP_MIN,
             target_temp_high=DEFAULT_SLEEP_MAX,
         )
-        # Real device has a very different temperature (stale from before restart)
         entity, hass = await self._setup_entity(
             last_state,
             inside_temp=20.0,
             real_climate_state=HVACMode.COOL.value,
-            real_climate_temp=25.0,  # Far from expected → would trigger false reset
+            real_climate_temp=25.0,  # wildly divergent setpoint
         )
-        # Preset must still be SLEEP, not reset to NONE
         assert entity._preset_mode == PRESET_SLEEP
-
-    @pytest.mark.asyncio
-    async def test_subscription_happens_after_sync(self):
-        """State-change subscription must occur after sync to prevent false resets."""
-        last_state = self._make_last_state(
-            hvac_mode=HVACMode.AUTO.value,
-            preset_mode=PRESET_AWAY,
-        )
-        hass = _make_hass_mock(
-            real_climate_state=HVACMode.OFF.value,
-            real_climate_temp=None,
-            inside_temp=20.0,
-        )
-        entity = _make_entity(hass)
-
-        call_order = []
-
-        with patch.object(
-            SmartClimateEntity, "async_get_last_state", return_value=last_state
-        ), patch.object(
-            SmartClimateEntity, "async_on_remove",
-            side_effect=lambda _: call_order.append("subscribe"),
-        ), patch(
-            "custom_components.smart_climate.climate.async_track_state_change_event",
-        ), patch.object(
-            SmartClimateEntity, "async_write_ha_state"
-        ), patch.object(
-            entity, "_async_sync_real_climate",
-            side_effect=lambda: call_order.append("sync"),
-        ):
-            await entity.async_added_to_hass()
-
-        # sync must come before subscribe
-        assert "sync" in call_order
-        assert "subscribe" in call_order
-        assert call_order.index("sync") < call_order.index("subscribe")
-        # Preset must remain intact after the full lifecycle
-        assert entity._preset_mode == PRESET_AWAY


### PR DESCRIPTION
Closes #43.

## Summary

Smart climate becomes the authoritative source of truth for `hvac_mode`, `preset_mode`, and setpoints. Real-climate state-change events are used only to mirror `hvac_action` for UI — they never write back. This eliminates the whole class of feedback-loop bugs where smart''s own writes were misread as external user overrides (#40 being the most recent).

## What goes away

- `_expected_real_target()` method
- `_last_real_mode` field
- `_updating_from_real` field
- External-change-detection branch in `_on_real_climate_update` (the branch that compared the real device''s reported setpoint to `_expected_real_target()` and cleared the preset on divergence)
- `_updating_from_control` early-return in `_on_real_climate_update` (no longer needed — the handler only mirrors `hvac_action`, which is idempotent)

## What stays

- `_desired_real_mode()` logic (HEAT/COOL/OFF decision) — unchanged
- `_async_sync_real_climate()` setpoint arithmetic (`low + deadband` for HEAT, `high - 1` for COOL) — unchanged
- `_updating_from_control` flag and its guard in `_async_sync_real_climate` — still prevents a concurrent sensor-triggered sync from racing a user-control sync
- State restoration — unchanged

`_on_real_climate_update` shrinks from ~50 lines to ~15. Net -178 LOC across both files.

## BREAKING CHANGE

Users whose wrapped climate device has a physical remote or knob will lose the implicit "drop out of preset when user overrides setpoint on the device" behavior. In @ocalvo''s deployment the wrapped device has no physical controls, which is why the feature was net-negative (producing only false positives from smart''s own writes). Deployments that need it should re-introduce it explicitly — for example, a Home Assistant Automation that sets `preset_mode: none` on the smart entity when a specific external trigger fires.

## Test plan

- [x] `pytest tests/test_climate.py` — 68 passed (down from 78; 10 tests for the removed feature deleted)
- [x] New consolidated test `test_real_setpoint_divergence_does_not_clear_preset` pins the master/slave contract across OFF / HEAT / COOL real-device states with wildly divergent reported setpoints
- [x] `TestExpectedRealTarget` class collapsed into `TestSyncedSetpoints` — still verifies `_async_sync_real_climate` sends `low + deadband` / `high - 1` / OFF correctly
- [x] `TestDesiredRealModeHysteresis` tests stripped of dead `last_mode` parameter; still cover all band-boundary cases
- [x] State-restoration tests updated to reflect master/slave invariants; `test_subscription_happens_after_sync` removed (tested implementation detail that no longer carries correctness weight)