### PR TITLE
fix: always send integer setpoint to real thermostat

### DIFF
--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -547,10 +547,11 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
                 )
             return
 
-        # In AUTO mode, target low + INSIDE_DEADBAND when heating so that the
-        # real device's own internal deadband causes it to start heating at
-        # approximately the configured low setpoint.  Target high - 1 when
-        # cooling to prevent integer-only devices from overshooting the band.
+        # In AUTO mode, target low + INSIDE_DEADBAND when heating so the real
+        # device's own internal deadband starts heating at approximately the
+        # configured low setpoint.  Target high - 1 when cooling to prevent
+        # overshooting the band.
+        low: float | None = None
         if self._hvac_mode == HVACMode.AUTO:
             low, high = self._active_range()
             if real_mode == HVACMode.HEAT:
@@ -560,10 +561,29 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         else:
             target_temp = self._target_temperature
 
+        # Real thermostats only accept whole-integer setpoints, and their
+        # advertised ``target_temp_step`` cannot be trusted to reflect that.
+        # Always round to an integer so the device stores exactly what we
+        # send — otherwise it silently rounds (e.g. 21.5 → 21) and every
+        # inside-sensor update drives another set_temperature call trying to
+        # "correct" the mismatch, producing the 21 ↔ 21.5 target flutter.
+        # Round directionally so engagement semantics survive: up for HEAT
+        # (keep heating at the low setpoint), down for COOL (keep cooling at
+        # the high setpoint).
+        if real_mode == HVACMode.HEAT:
+            target_temp = float(math.ceil(target_temp))
+        else:  # COOL
+            target_temp = float(math.floor(target_temp))
+            if low is not None:
+                target_temp = max(low, target_temp)
+
         current_temp = real_state.attributes.get("temperature")
 
+        # Tolerance must cover the full integer step so the next sensor
+        # update doesn't trigger a spurious resend when the device is
+        # already holding the exact value we sent.
         mode_changed = current_mode != real_mode.value
-        temp_changed = current_temp is None or abs(float(current_temp) - target_temp) > 0.1
+        temp_changed = current_temp is None or abs(float(current_temp) - target_temp) >= 0.5
 
         if not (mode_changed or temp_changed):
             return

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -668,10 +668,13 @@ class TestSyncedSetpoints:
 
     @pytest.mark.asyncio
     async def test_sync_sends_low_plus_deadband_when_heating(self):
-        """_async_sync_real_climate sends low + INSIDE_DEADBAND when in HEAT.
+        """_async_sync_real_climate targets low + INSIDE_DEADBAND when in HEAT.
 
-        This compensates for the real device's own internal deadband so it
-        starts heating at approximately the configured low setpoint.
+        The real device's own internal deadband then starts heating at
+        approximately the configured low setpoint.  The value is rounded up
+        to a whole integer because real thermostats only accept integer
+        setpoints and silently round anything else, which otherwise drives a
+        resend-every-sensor-update loop (see test_sync_heat_target_is_integer).
         """
         hass = _make_hass_mock(
             real_climate_state=HVACMode.HEAT.value,
@@ -687,7 +690,83 @@ class TestSyncedSetpoints:
         call_args = hass.services.async_call.call_args
         assert call_args[0][0] == "climate"
         assert call_args[0][1] == "set_temperature"
-        assert call_args[0][2]["temperature"] == DEFAULT_HOME_MIN + INSIDE_DEADBAND
+        assert call_args[0][2]["temperature"] == math.ceil(
+            DEFAULT_HOME_MIN + INSIDE_DEADBAND
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_heat_target_is_integer(self):
+        """Issue #46 regression: HEAT target must be a whole integer.
+
+        Real thermostats only accept integer setpoints.  Sending a
+        half-degree value like 21.5 is silently rounded to 21 by the device,
+        leaving current_temp != target_temp forever, which fires a fresh
+        set_temperature call on every inside-sensor update and manifests as
+        the setpoint fluttering between 21 and 21.5 in the UI.  We round up
+        for HEAT so the effective engagement point stays at low.
+        """
+        low, high = 21.0, 23.0
+        hass = _make_hass_mock(
+            real_climate_state=HVACMode.HEAT.value,
+            real_climate_temp=21,  # device rounded our previous 21.5 to 21
+            inside_temp=low - 1,
+        )
+        entity = _make_entity(hass)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_NONE
+        entity._target_temp_low = low
+        entity._target_temp_high = high
+        entity._current_temperature = low - 1
+        await entity._async_sync_real_climate()
+        call_args = hass.services.async_call.call_args
+        sent = call_args[0][2]["temperature"]
+        assert sent == int(sent), f"expected integer target, got {sent}"
+        assert sent == 22  # ceil(21 + 0.5)
+
+    @pytest.mark.asyncio
+    async def test_sync_heat_no_resend_when_device_holds_integer_target(self):
+        """Once the integer target is stored by the device, no resend happens.
+
+        The previous behaviour sent 21.5, the device stored 21 (integer
+        rounding), and the ``temp_changed`` check (`abs(21 - 21.5) > 0.1`)
+        fired on every sensor update.  Rounding to an integer means the
+        device's reported setpoint matches what we sent, so sync returns
+        early and the flutter disappears.
+        """
+        low, high = 21.0, 23.0
+        hass = _make_hass_mock(
+            real_climate_state=HVACMode.HEAT.value,
+            real_climate_temp=22,  # matches what we now send (ceil(21.5))
+            inside_temp=low - 1,
+        )
+        entity = _make_entity(hass)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_NONE
+        entity._target_temp_low = low
+        entity._target_temp_high = high
+        entity._current_temperature = low - 1
+        await entity._async_sync_real_climate()
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_cool_target_is_integer(self):
+        """Mirror of the HEAT test — COOL target must also be a whole integer."""
+        low, high = 21.0, 23.0
+        hass = _make_hass_mock(
+            real_climate_state=HVACMode.COOL.value,
+            real_climate_temp=None,
+            inside_temp=high + 1,
+        )
+        entity = _make_entity(hass)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_NONE
+        entity._target_temp_low = low
+        entity._target_temp_high = high
+        entity._current_temperature = high + 1
+        await entity._async_sync_real_climate()
+        call_args = hass.services.async_call.call_args
+        sent = call_args[0][2]["temperature"]
+        assert sent == int(sent), f"expected integer target, got {sent}"
 
     @pytest.mark.asyncio
     async def test_sync_sends_off_when_in_band(self):


### PR DESCRIPTION
Fixes #46.

## Root cause

Real thermostats only accept whole-integer setpoints, and their advertised `target_temp_step` can''t be trusted to reflect that. `_async_sync_real_climate` was sending `low + INSIDE_DEADBAND` (e.g. `21.5`), the device silently rounded that to `21`, and the next `_on_inside_sensor_update` saw `abs(21 - 21.5) > 0.1` — so it fired another `climate.set_temperature` with the same 21.5, the device rounded again, and so on.

User-visible symptoms:

- The real device''s setpoint fluttered between `21` (device''s rounded value) and `21.5` (our resend) in the UI.
- Every resend also reposted `hvac_mode=HEAT`, which appears in history as rapid heat/cool churn.

## Fix

Always round the target to a whole integer before sending: `ceil` for HEAT (so heating still kicks in at the low setpoint), `floor` for COOL (so cooling still kicks in at the high). The AUTO COOL path keeps the existing `max(low, …)` clamp so narrow bands don''t drop below the low setpoint.

Also widens the no-op tolerance from `> 0.1` to `>= 0.5` (the integer step), so the device''s own reported setpoint can no longer trip a spurious resend on the next sensor update.

## Test plan

- [x] Added `test_sync_heat_target_is_integer` — regression test for #46.
- [x] Added `test_sync_heat_no_resend_when_device_holds_integer_target` — proves the sync loop breaks once the device echoes back the integer we sent.
- [x] Added `test_sync_cool_target_is_integer` — symmetric check for COOL.
- [x] Updated `test_sync_sends_low_plus_deadband_when_heating` to expect the rounded value and cross-reference the new regression test.
- [x] Full suite: `pytest` — 71 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)