### PR TITLE
fix: hysteresis on AUTO mode-commit edge to stop real-device flapping

### DIFF
--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -155,6 +155,13 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # bias is only kept for this long before we force the device off.
         self._in_band_since: datetime.datetime | None = None
 
+        # Last HEAT/COOL/OFF decision pushed to the real device in AUTO mode.
+        # Used as the "previous state" input for mode hysteresis so that tiny
+        # inside-sensor jitter across the commit edge (high - DEADBAND or
+        # low + DEADBAND) does not flip the real device's mode on every
+        # sensor update.  None means no AUTO decision has been made yet.
+        self._last_real_mode: HVACMode | None = None
+
     # ------------------------------------------------------------------
     # ClimateEntity properties
     # ------------------------------------------------------------------
@@ -486,9 +493,28 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # COOL is checked first to avoid over-heating a near-target room.
         if inside >= high - INSIDE_DEADBAND:
             self._in_band_since = None  # exited the comfortable zone
+            self._last_real_mode = HVACMode.COOL
             return HVACMode.COOL
         if inside <= low + INSIDE_DEADBAND:
             self._in_band_since = None  # exited the comfortable zone
+            self._last_real_mode = HVACMode.HEAT
+            return HVACMode.HEAT
+
+        # In-band mode hysteresis.  The commit edges (high - DEADBAND and
+        # low + DEADBAND) have no hysteresis on their own: a sensor tick of
+        # ±0.01 °C across one of them bounces the decision between the
+        # committed mode and the in-band outside-bias below, and when the
+        # outside temperature is outside the band that bias returns the
+        # *opposite* mode — producing the observed COOL↔HEAT flapping at
+        # the band edge.  Stick with the previously-chosen mode until the
+        # inside temperature has travelled all the way to the comfort-band
+        # midpoint, i.e. only release the commit once the room has genuinely
+        # moved towards the other edge.  This is the mode-axis analogue of
+        # the setpoint resend loop that #46 / #47 fixed.
+        mid = (low + high) / 2.0
+        if self._last_real_mode == HVACMode.COOL and inside > mid:
+            return HVACMode.COOL
+        if self._last_real_mode == HVACMode.HEAT and inside < mid:
             return HVACMode.HEAT
 
         # Temperature is comfortably within the band.
@@ -510,12 +536,15 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             self._outside_temperature
         ):
             if self._outside_temperature < low:
+                self._last_real_mode = HVACMode.HEAT
                 return HVACMode.HEAT
             if self._outside_temperature > high:
+                self._last_real_mode = HVACMode.COOL
                 return HVACMode.COOL
 
         # No outside sensor, outside temp is within the comfort range, or the
         # inside temperature has been comfortable for too long – turn off.
+        self._last_real_mode = HVACMode.OFF
         return HVACMode.OFF
 
     # ------------------------------------------------------------------

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -201,6 +201,108 @@ class TestDesiredRealMode:
         assert entity._desired_real_mode() == HVACMode.AUTO
 
 
+class TestBandEdgeModeHysteresis:
+    """Regression tests for mode flapping at the commit-edge (#49).
+
+    The commit thresholds `high - INSIDE_DEADBAND` / `low + INSIDE_DEADBAND`
+    are exact boundaries: a sensor tick of ±0.01 °C across one of them used
+    to flip the real device's mode on every update, and when the outside
+    temperature was outside the comfort band the in-band outside-bias
+    returned the *opposite* mode (COOL ↔ HEAT at max amplitude).  The
+    hysteresis rule added in this file keeps the previously-chosen mode
+    until the inside temperature has travelled all the way to the
+    comfort-band midpoint before reconsidering.
+    """
+
+    def _entity(self, inside: float, outside: float | None = None):
+        hass = _make_hass_mock(inside_temp=inside, outside_temp=outside)
+        config = {
+            CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
+            CONF_INSIDE_SENSOR: INSIDE_SENSOR_ID,
+        }
+        if outside is not None:
+            config[CONF_OUTSIDE_SENSOR] = OUTSIDE_SENSOR_ID
+        entity = _make_entity(hass, config)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_HOME
+        entity._current_temperature = inside
+        entity._outside_temperature = outside
+        return entity
+
+    def _set_inside(self, entity, inside):
+        entity._current_temperature = inside
+
+    def test_observed_flap_scenario_stays_cool(self):
+        """Exact #49 scenario: HOME preset, cold outside, inside jittering
+        across the upper commit edge (high - INSIDE_DEADBAND).
+
+        Without hysteresis the sequence produced COOL, HEAT, COOL, HEAT
+        (the outside-bias returns HEAT because outside < low).  With
+        hysteresis the mode commits to COOL on the first tick at the edge
+        and refuses to flip to HEAT until inside has dropped all the way to
+        the comfort-band midpoint.
+        """
+        edge = DEFAULT_HOME_MAX - INSIDE_DEADBAND  # 23.5 with defaults
+        entity = self._entity(inside=edge, outside=DEFAULT_HOME_MIN - 5)
+
+        assert entity._desired_real_mode() == HVACMode.COOL
+        self._set_inside(entity, edge - 0.01)
+        assert entity._desired_real_mode() == HVACMode.COOL
+        self._set_inside(entity, edge)
+        assert entity._desired_real_mode() == HVACMode.COOL
+        self._set_inside(entity, edge - 0.01)
+        assert entity._desired_real_mode() == HVACMode.COOL
+
+    def test_symmetric_flap_at_low_edge_stays_heat(self):
+        """Mirror of the #49 scenario at the lower commit edge: hot outside,
+        inside jittering at low + INSIDE_DEADBAND — must stay HEAT."""
+        edge = DEFAULT_HOME_MIN + INSIDE_DEADBAND  # 21.5 with defaults
+        entity = self._entity(inside=edge, outside=DEFAULT_HOME_MAX + 5)
+
+        assert entity._desired_real_mode() == HVACMode.HEAT
+        self._set_inside(entity, edge + 0.01)
+        assert entity._desired_real_mode() == HVACMode.HEAT
+        self._set_inside(entity, edge)
+        assert entity._desired_real_mode() == HVACMode.HEAT
+        self._set_inside(entity, edge + 0.01)
+        assert entity._desired_real_mode() == HVACMode.HEAT
+
+    def test_cool_released_when_inside_drops_past_midpoint(self):
+        """After committing to COOL, a real excursion past the midpoint
+        releases hysteresis and the outside-bias can pick HEAT again."""
+        edge = DEFAULT_HOME_MAX - INSIDE_DEADBAND  # 23.5
+        entity = self._entity(inside=edge, outside=DEFAULT_HOME_MIN - 5)
+        assert entity._desired_real_mode() == HVACMode.COOL  # commits COOL
+
+        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
+        # Just past the midpoint towards the low edge — hysteresis releases.
+        self._set_inside(entity, mid - 0.01)
+        assert entity._desired_real_mode() == HVACMode.HEAT
+
+    def test_heat_released_when_inside_rises_past_midpoint(self):
+        """Symmetric release for a previously-HEAT decision."""
+        edge = DEFAULT_HOME_MIN + INSIDE_DEADBAND  # 21.5
+        entity = self._entity(inside=edge, outside=DEFAULT_HOME_MAX + 5)
+        assert entity._desired_real_mode() == HVACMode.HEAT  # commits HEAT
+
+        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2  # 22.0
+        self._set_inside(entity, mid + 0.01)
+        assert entity._desired_real_mode() == HVACMode.COOL
+
+    def test_first_entry_without_prior_mode_uses_outside_bias(self):
+        """With no prior AUTO decision, in-band outside-bias logic is
+        unchanged — cold outside → HEAT, warm outside → COOL."""
+        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
+
+        cold = self._entity(inside=mid, outside=DEFAULT_HOME_MIN - 5)
+        assert cold._last_real_mode is None
+        assert cold._desired_real_mode() == HVACMode.HEAT
+
+        warm = self._entity(inside=mid, outside=DEFAULT_HOME_MAX + 5)
+        assert warm._last_real_mode is None
+        assert warm._desired_real_mode() == HVACMode.COOL
+
+
 class TestDesiredRealModeHysteresis:
     """Tests for the band-boundary and OFF behaviour in _desired_real_mode."""
 


### PR DESCRIPTION
Fixes #49.

## Root cause

`_desired_real_mode` has no hysteresis **on** the commit edges (`high - INSIDE_DEADBAND` / `low + INSIDE_DEADBAND`), and the adjacent in-band outside-bias returns the *opposite* mode when the outside temperature is outside the comfort band.  Any 0.01 °C sensor jitter across the edge flips the real device's mode to the maximum-amplitude opposite on every inside-sensor update.

`INSIDE_DEADBAND` moves the commit edges away from the band midpoint, but does not add hysteresis on those edges. The mode axis had the same structural bug that #46 had on the setpoint axis — now fixed symmetrically.

## Fix

Track the last HEAT/COOL/OFF decision made in AUTO mode in `_last_real_mode`. In the in-band region, before falling through to the outside-bias / stable-timeout logic, keep returning the previously-committed mode while the inside temperature remains on the committed side of the comfort-band midpoint. Only release once the room has genuinely moved past the midpoint towards the other edge.

This is deliberately narrow: the outside-sensor bias and `STABLE_IN_BAND_TIMEOUT` logic are unchanged for a fresh entry into the band (when `_last_real_mode is None`), so existing behavior is preserved.

## Test plan

- [x] Added `TestBandEdgeModeHysteresis` (5 tests):
  - `test_observed_flap_scenario_stays_cool` — exact #49 reproducer at the upper edge with cold outside.
  - `test_symmetric_flap_at_low_edge_stays_heat` — mirror at the lower edge with hot outside.
  - `test_cool_released_when_inside_drops_past_midpoint` — hysteresis releases on genuine excursion.
  - `test_heat_released_when_inside_rises_past_midpoint` — symmetric release.
  - `test_first_entry_without_prior_mode_uses_outside_bias` — existing behavior preserved on first entry.
- [x] `pytest`: 76 passed (71 existing + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)