### PR TITLE
fix: return OFF in-band to stop overnight heat/cool cycling

### DIFF
--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -8,7 +8,6 @@ Wraps a physical climate device and adds:
 """
 from __future__ import annotations
 
-import datetime
 import logging
 import math
 from typing import Any
@@ -54,7 +53,6 @@ from .const import (
     MAX_TEMP,
     MIN_TEMP,
     MIN_TEMP_DIFF,
-    STABLE_IN_BAND_TIMEOUT,
     TEMP_STEP,
 )
 
@@ -148,12 +146,6 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # Guard flag – skip sensor-triggered syncs while a control call is in
         # flight so the two paths do not issue overlapping service calls.
         self._updating_from_control: bool = False
-
-        # Timestamp at which the inside temperature first entered the
-        # comfortable mid-band zone (between low+deadband and high-deadband).
-        # Used to enforce STABLE_IN_BAND_TIMEOUT: the outside-sensor HEAT/COOL
-        # bias is only kept for this long before we force the device off.
-        self._in_band_since: datetime.datetime | None = None
 
         # Last HEAT/COOL/OFF decision pushed to the real device in AUTO mode.
         # Used as the "previous state" input for mode hysteresis so that tiny
@@ -492,58 +484,34 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # For sub-1 °C bands the device will be either HEAT or COOL (never OFF);
         # COOL is checked first to avoid over-heating a near-target room.
         if inside >= high - INSIDE_DEADBAND:
-            self._in_band_since = None  # exited the comfortable zone
             self._last_real_mode = HVACMode.COOL
             return HVACMode.COOL
         if inside <= low + INSIDE_DEADBAND:
-            self._in_band_since = None  # exited the comfortable zone
             self._last_real_mode = HVACMode.HEAT
             return HVACMode.HEAT
 
         # In-band mode hysteresis.  The commit edges (high - DEADBAND and
         # low + DEADBAND) have no hysteresis on their own: a sensor tick of
-        # ±0.01 °C across one of them bounces the decision between the
-        # committed mode and the in-band outside-bias below, and when the
-        # outside temperature is outside the band that bias returns the
-        # *opposite* mode — producing the observed COOL↔HEAT flapping at
-        # the band edge.  Stick with the previously-chosen mode until the
-        # inside temperature has travelled all the way to the comfort-band
-        # midpoint, i.e. only release the commit once the room has genuinely
-        # moved towards the other edge.  This is the mode-axis analogue of
-        # the setpoint resend loop that #46 / #47 fixed.
+        # ±0.01 °C across one of them would bounce the decision between the
+        # committed mode and the in-band OFF below.  Stick with the
+        # previously-chosen HEAT or COOL commitment until the inside
+        # temperature has travelled to the comfort-band midpoint, i.e. only
+        # release the commit once the room has genuinely moved towards the
+        # other edge.  Mode-axis analogue of the setpoint resend loop that
+        # #46 / #47 fixed.
         mid = (low + high) / 2.0
         if self._last_real_mode == HVACMode.COOL and inside > mid:
             return HVACMode.COOL
         if self._last_real_mode == HVACMode.HEAT and inside < mid:
             return HVACMode.HEAT
 
-        # Temperature is comfortably within the band.
-        # Record when we first entered this comfortable state so we can enforce
-        # a maximum run time for the outside-sensor HEAT/COOL bias.
-        now = datetime.datetime.now(datetime.timezone.utc)
-        if self._in_band_since is None:
-            self._in_band_since = now
-
-        # Use the outside sensor to decide whether to maintain HEAT or COOL
-        # instead of turning the device off.  This avoids rapid off/heat/off
-        # (winter) or off/cool/off (summer) cycling when the inside temp
-        # fluctuates near the midpoint of the comfort range.
-        # However, if the temperature has been stable in the band for longer
-        # than STABLE_IN_BAND_TIMEOUT, the room is genuinely comfortable and
-        # continuing to run the HVAC wastes energy – turn it off regardless.
-        elapsed = (now - self._in_band_since).total_seconds()
-        if elapsed < STABLE_IN_BAND_TIMEOUT and self._outside_temperature is not None and not math.isnan(
-            self._outside_temperature
-        ):
-            if self._outside_temperature < low:
-                self._last_real_mode = HVACMode.HEAT
-                return HVACMode.HEAT
-            if self._outside_temperature > high:
-                self._last_real_mode = HVACMode.COOL
-                return HVACMode.COOL
-
-        # No outside sensor, outside temp is within the comfort range, or the
-        # inside temperature has been comfortable for too long – turn off.
+        # Temperature is comfortably within the band → turn the real device
+        # off.  The previous outside-sensor in-band bias (PR #35) was
+        # removed in PR #52: combined with the hysteresis above it produced
+        # large active HEAT↔COOL swings across the whole band (#52), which
+        # is worse than the rapid off/heat/off flutter that #35 was trying
+        # to suppress.  With the commit hysteresis in place, OFF in-band is
+        # both simpler and kinder to the HVAC.
         self._last_real_mode = HVACMode.OFF
         return HVACMode.OFF
 

--- a/custom_components/smart_climate/const.py
+++ b/custom_components/smart_climate/const.py
@@ -31,13 +31,9 @@ TEMP_STEP = 0.5
 # Minimum allowed difference between low and high setpoints
 MIN_TEMP_DIFF = 0.5
 
-# Hysteresis deadband (°C) around the comfort-band midpoint used when the
-# inside temperature is already within the target range.  Without this buffer
-# any sensor jitter near the midpoint causes rapid HEAT ↔ COOL cycling.
+# Distance (°C) from each edge of the comfort band at which the real device
+# is committed to HEAT (at low + INSIDE_DEADBAND) or COOL (at high -
+# INSIDE_DEADBAND).  Inside this margin the device is kept OFF, and hysteresis
+# in _desired_real_mode stops the committed mode from flipping back to OFF on
+# sensor jitter across the commit edge.
 INSIDE_DEADBAND = 0.5
-
-# How long (seconds) the inside temperature must remain comfortably within the
-# comfort band while the outside-sensor logic would otherwise keep the real
-# device running before we force it off.  Prevents the HVAC from running
-# indefinitely when the room is already comfortable.
-STABLE_IN_BAND_TIMEOUT = 900  # 15 minutes

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,7 +1,6 @@
 """Tests for the Smart Climate entity."""
 from __future__ import annotations
 
-import datetime
 import math
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
@@ -28,7 +27,6 @@ from custom_components.smart_climate.const import (
     DEFAULT_AWAY_MAX,
     INSIDE_DEADBAND,
     MIN_TEMP_DIFF,
-    STABLE_IN_BAND_TIMEOUT,
 )
 
 REAL_CLIMATE_ID = "climate.real_ac"
@@ -164,17 +162,23 @@ class TestDesiredRealMode:
         entity = self._entity(inside=mid)
         assert entity._desired_real_mode() == HVACMode.OFF
 
-    def test_auto_in_range_cold_outside_returns_heat(self):
-        """Inside temp in range, cold outside → HEAT to avoid off/heat cycling."""
+    def test_auto_in_range_cold_outside_returns_off(self):
+        """Inside temp in range, cold outside → OFF.
+
+        Regression for #52: the previous outside-sensor in-band bias returned
+        HEAT here, which combined with the commit-edge hysteresis (#49)
+        produced active HEAT↔COOL cycling across the whole band overnight.
+        The in-band decision is now OFF regardless of outside temperature.
+        """
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         entity = self._entity(inside=mid, outside=DEFAULT_HOME_MIN - 5)
-        assert entity._desired_real_mode() == HVACMode.HEAT
+        assert entity._desired_real_mode() == HVACMode.OFF
 
-    def test_auto_in_range_warm_outside_returns_cool(self):
-        """Inside temp in range, warm outside → COOL to avoid off/cool cycling."""
+    def test_auto_in_range_warm_outside_returns_off(self):
+        """Inside temp in range, warm outside → OFF (see #52)."""
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         entity = self._entity(inside=mid, outside=DEFAULT_HOME_MAX + 5)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        assert entity._desired_real_mode() == HVACMode.OFF
 
     def test_auto_in_range_outside_in_range_returns_off(self):
         """Inside temp in range, outside also in range → OFF."""
@@ -206,12 +210,10 @@ class TestBandEdgeModeHysteresis:
 
     The commit thresholds `high - INSIDE_DEADBAND` / `low + INSIDE_DEADBAND`
     are exact boundaries: a sensor tick of ±0.01 °C across one of them used
-    to flip the real device's mode on every update, and when the outside
-    temperature was outside the comfort band the in-band outside-bias
-    returned the *opposite* mode (COOL ↔ HEAT at max amplitude).  The
-    hysteresis rule added in this file keeps the previously-chosen mode
-    until the inside temperature has travelled all the way to the
-    comfort-band midpoint before reconsidering.
+    to flip the real device's mode on every update (COOL ↔ OFF ↔ HEAT).
+    The hysteresis rule keeps the previously-chosen mode until the inside
+    temperature has travelled all the way to the comfort-band midpoint
+    before releasing to OFF.
     """
 
     def _entity(self, inside: float, outside: float | None = None):
@@ -233,17 +235,16 @@ class TestBandEdgeModeHysteresis:
         entity._current_temperature = inside
 
     def test_observed_flap_scenario_stays_cool(self):
-        """Exact #49 scenario: HOME preset, cold outside, inside jittering
-        across the upper commit edge (high - INSIDE_DEADBAND).
+        """Exact #49 scenario: HOME preset, inside jittering across the
+        upper commit edge (high - INSIDE_DEADBAND).
 
-        Without hysteresis the sequence produced COOL, HEAT, COOL, HEAT
-        (the outside-bias returns HEAT because outside < low).  With
-        hysteresis the mode commits to COOL on the first tick at the edge
-        and refuses to flip to HEAT until inside has dropped all the way to
-        the comfort-band midpoint.
+        Without hysteresis the sequence produced COOL, OFF, COOL, OFF on
+        every sensor tick.  With hysteresis the mode commits to COOL on
+        the first tick at the edge and refuses to release until inside has
+        dropped all the way to the comfort-band midpoint.
         """
         edge = DEFAULT_HOME_MAX - INSIDE_DEADBAND  # 23.5 with defaults
-        entity = self._entity(inside=edge, outside=DEFAULT_HOME_MIN - 5)
+        entity = self._entity(inside=edge)
 
         assert entity._desired_real_mode() == HVACMode.COOL
         self._set_inside(entity, edge - 0.01)
@@ -254,10 +255,10 @@ class TestBandEdgeModeHysteresis:
         assert entity._desired_real_mode() == HVACMode.COOL
 
     def test_symmetric_flap_at_low_edge_stays_heat(self):
-        """Mirror of the #49 scenario at the lower commit edge: hot outside,
-        inside jittering at low + INSIDE_DEADBAND — must stay HEAT."""
+        """Mirror of the #49 scenario at the lower commit edge: inside
+        jittering at low + INSIDE_DEADBAND — must stay HEAT."""
         edge = DEFAULT_HOME_MIN + INSIDE_DEADBAND  # 21.5 with defaults
-        entity = self._entity(inside=edge, outside=DEFAULT_HOME_MAX + 5)
+        entity = self._entity(inside=edge)
 
         assert entity._desired_real_mode() == HVACMode.HEAT
         self._set_inside(entity, edge + 0.01)
@@ -267,40 +268,44 @@ class TestBandEdgeModeHysteresis:
         self._set_inside(entity, edge + 0.01)
         assert entity._desired_real_mode() == HVACMode.HEAT
 
-    def test_cool_released_when_inside_drops_past_midpoint(self):
+    def test_cool_released_to_off_when_inside_drops_past_midpoint(self):
         """After committing to COOL, a real excursion past the midpoint
-        releases hysteresis and the outside-bias can pick HEAT again."""
+        releases hysteresis and the in-band decision is OFF (#52)."""
         edge = DEFAULT_HOME_MAX - INSIDE_DEADBAND  # 23.5
-        entity = self._entity(inside=edge, outside=DEFAULT_HOME_MIN - 5)
+        entity = self._entity(inside=edge)
         assert entity._desired_real_mode() == HVACMode.COOL  # commits COOL
 
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         # Just past the midpoint towards the low edge — hysteresis releases.
         self._set_inside(entity, mid - 0.01)
-        assert entity._desired_real_mode() == HVACMode.HEAT
+        assert entity._desired_real_mode() == HVACMode.OFF
 
-    def test_heat_released_when_inside_rises_past_midpoint(self):
-        """Symmetric release for a previously-HEAT decision."""
+    def test_heat_released_to_off_when_inside_rises_past_midpoint(self):
+        """Symmetric release for a previously-HEAT decision (#52)."""
         edge = DEFAULT_HOME_MIN + INSIDE_DEADBAND  # 21.5
-        entity = self._entity(inside=edge, outside=DEFAULT_HOME_MAX + 5)
+        entity = self._entity(inside=edge)
         assert entity._desired_real_mode() == HVACMode.HEAT  # commits HEAT
 
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2  # 22.0
         self._set_inside(entity, mid + 0.01)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        assert entity._desired_real_mode() == HVACMode.OFF
 
-    def test_first_entry_without_prior_mode_uses_outside_bias(self):
-        """With no prior AUTO decision, in-band outside-bias logic is
-        unchanged — cold outside → HEAT, warm outside → COOL."""
+    def test_first_entry_without_prior_mode_returns_off_in_band(self):
+        """With no prior AUTO decision and inside in the band, return OFF.
+
+        Regression for #52: previously this returned HEAT or COOL based on
+        the outside sensor, which combined with the hysteresis above
+        produced overnight active HEAT↔COOL cycling across the whole band.
+        """
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
 
         cold = self._entity(inside=mid, outside=DEFAULT_HOME_MIN - 5)
         assert cold._last_real_mode is None
-        assert cold._desired_real_mode() == HVACMode.HEAT
+        assert cold._desired_real_mode() == HVACMode.OFF
 
         warm = self._entity(inside=mid, outside=DEFAULT_HOME_MAX + 5)
         assert warm._last_real_mode is None
-        assert warm._desired_real_mode() == HVACMode.COOL
+        assert warm._desired_real_mode() == HVACMode.OFF
 
 
 class TestDesiredRealModeHysteresis:
@@ -400,124 +405,6 @@ class TestDesiredRealModeHysteresis:
         """At high - deadband (COOL boundary) → COOL."""
         entity = self._entity(inside=DEFAULT_HOME_MAX - INSIDE_DEADBAND)
         assert entity._desired_real_mode() == HVACMode.COOL
-
-
-# ---------------------------------------------------------------------------
-# Unit tests – stable-in-band timeout (STABLE_IN_BAND_TIMEOUT)
-# ---------------------------------------------------------------------------
-
-class TestStableInBandTimeout:
-    """Tests for the 15-minute stable-in-band shut-off logic."""
-
-    def _entity(self, inside: float, outside: float | None = None):
-        hass = _make_hass_mock(inside_temp=inside, outside_temp=outside)
-        config = {
-            CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
-            CONF_INSIDE_SENSOR: INSIDE_SENSOR_ID,
-        }
-        if outside is not None:
-            config[CONF_OUTSIDE_SENSOR] = OUTSIDE_SENSOR_ID
-        entity = _make_entity(hass, config)
-        entity._hvac_mode = HVACMode.AUTO
-        entity._preset_mode = PRESET_HOME
-        entity._current_temperature = inside
-        entity._outside_temperature = outside
-        return entity
-
-    def test_first_entry_cold_outside_returns_heat(self):
-        """On first entering the band with cold outside, return HEAT (timer not expired)."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, outside=DEFAULT_HOME_MIN - 5)
-        # _in_band_since is None → first entry
-        assert entity._in_band_since is None
-        assert entity._desired_real_mode() == HVACMode.HEAT
-        # Timer should now be set
-        assert entity._in_band_since is not None
-
-    def test_first_entry_warm_outside_returns_cool(self):
-        """On first entering the band with warm outside, return COOL (timer not expired)."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, outside=DEFAULT_HOME_MAX + 5)
-        assert entity._desired_real_mode() == HVACMode.COOL
-        assert entity._in_band_since is not None
-
-    def test_after_timeout_cold_outside_returns_off(self):
-        """After STABLE_IN_BAND_TIMEOUT seconds in band, return OFF even with cold outside."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, outside=DEFAULT_HOME_MIN - 5)
-        # Simulate that we entered the band 15+ minutes ago
-        entity._in_band_since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            seconds=STABLE_IN_BAND_TIMEOUT + 1
-        )
-        assert entity._desired_real_mode() == HVACMode.OFF
-
-    def test_after_timeout_warm_outside_returns_off(self):
-        """After STABLE_IN_BAND_TIMEOUT seconds in band, return OFF even with warm outside."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, outside=DEFAULT_HOME_MAX + 5)
-        entity._in_band_since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            seconds=STABLE_IN_BAND_TIMEOUT + 1
-        )
-        assert entity._desired_real_mode() == HVACMode.OFF
-
-    def test_just_before_timeout_still_heats(self):
-        """Just before timeout, HVAC should still keep running."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, outside=DEFAULT_HOME_MIN - 5)
-        entity._in_band_since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            seconds=STABLE_IN_BAND_TIMEOUT - 60
-        )
-        assert entity._desired_real_mode() == HVACMode.HEAT
-
-    def test_timer_resets_when_temp_exits_band_low(self):
-        """Timer is cleared when temperature drops into the heating zone."""
-        entity = self._entity(inside=DEFAULT_HOME_MIN + INSIDE_DEADBAND - 0.1, outside=DEFAULT_HOME_MIN - 5)
-        entity._in_band_since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            seconds=STABLE_IN_BAND_TIMEOUT + 1
-        )
-        # Temp is in the heating zone → HEAT, timer should be reset
-        result = entity._desired_real_mode()
-        assert result == HVACMode.HEAT
-        assert entity._in_band_since is None
-
-    def test_timer_resets_when_temp_exits_band_high(self):
-        """Timer is cleared when temperature rises into the cooling zone."""
-        entity = self._entity(inside=DEFAULT_HOME_MAX - INSIDE_DEADBAND + 0.1, outside=DEFAULT_HOME_MAX + 5)
-        entity._in_band_since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            seconds=STABLE_IN_BAND_TIMEOUT + 1
-        )
-        result = entity._desired_real_mode()
-        assert result == HVACMode.COOL
-        assert entity._in_band_since is None
-
-    def test_after_band_exit_and_reentry_timer_restarted(self):
-        """Re-entering the band after an exit starts a fresh 15-minute timer."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, outside=DEFAULT_HOME_MIN - 5)
-
-        # Simulate expired timer
-        entity._in_band_since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            seconds=STABLE_IN_BAND_TIMEOUT + 1
-        )
-        # Timed out → should return OFF
-        assert entity._desired_real_mode() == HVACMode.OFF
-
-        # Now temp exits the band (clearly in heating zone)
-        entity._current_temperature = DEFAULT_HOME_MIN + INSIDE_DEADBAND - 0.1
-        entity._desired_real_mode()  # resets _in_band_since
-        assert entity._in_band_since is None
-
-        # Back in band – timer is fresh
-        entity._current_temperature = mid
-        result = entity._desired_real_mode()
-        assert result == HVACMode.HEAT  # fresh timer, should keep running
-        assert entity._in_band_since is not None
-
-    def test_no_outside_sensor_in_band_returns_off_immediately(self):
-        """Without outside sensor, in-band temperature returns OFF immediately (no timer needed)."""
-        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
-        entity = self._entity(inside=mid, outside=None)
-        assert entity._desired_real_mode() == HVACMode.OFF
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes the outside-sensor in-band bias (`_desired_real_mode` no longer peeks at `outside` to pre-choose HEAT or COOL inside the comfort band).
- Removes the `STABLE_IN_BAND_TIMEOUT` 15-minute timer that covered for the bias.
- In AUTO mode, when inside is comfortably within the band, the real device is now simply **OFF** — guarded by the midpoint-release hysteresis added in #50.

## Why

After #50 shipped as v1.0.2, overnight observation (5h window, 23:00–04:00) showed the real thermostat actively cycling:

- **29 real hvac_mode transitions** (`off→cool→heat→off…`) in 5 hours
- Inside temperature swing of **0.97 °C** — worse than the pre-#49 flutter the band was trying to keep stable
- Median interval between cycles ≈ 10 min (matches the 15-min `STABLE_IN_BAND_TIMEOUT` plus drift time)

Root cause: with both `#50` hysteresis **and** the `#35` outside-bias active, the in-band decision was always HEAT or COOL depending on outside temperature. Once inside drifted past the midpoint, hysteresis released, the opposite mode engaged, the room overshot back past the midpoint, hysteresis released again, and so on — a full-amplitude fight across the whole band.

User feedback:
> "the best outcome would be to simply turn off if we are right in the band, which I think we do"

That's now the behavior.

## Behavior in a typical HOME (21–24 °C) night

Before (v1.0.2):
```
22.5  COOL  (commit edge, cold outside bias → HEAT fighting)
22.0  HEAT  (after midpoint release, outside bias)
22.5  COOL  (overshoot)
…      repeat every ~10–15 min
```

After (this PR):
```
22.5  COOL   (commit)
22.0  OFF    (hysteresis releases at midpoint)
21.5  HEAT   (only when it reaches the lower commit edge)
22.0  OFF
…      passive drift between commit edges, no active fight
```

## Tests

- Removed `TestStableInBandTimeout` (8 tests) — constant no longer exists.
- Updated `test_auto_in_range_cold_outside_returns_heat` / `..._warm_outside_returns_cool` → now assert `OFF`.
- Updated `TestBandEdgeModeHysteresis` release tests to assert `OFF` after midpoint release (previously HEAT/COOL via outside bias).
- `test_first_entry_without_prior_mode_uses_outside_bias` → `test_first_entry_without_prior_mode_returns_off_in_band`.
- All 67 remaining tests pass.

## Test plan

- [x] `pytest -q` — 67 passed
- [ ] Deploy to `hawa`, watch `climate.thermostat` hvac_mode for 24h — expect OFF to dominate in-band, with HEAT/COOL only at the commit edges
- [ ] Confirm inside-temperature swing stays under ~0.5 °C overnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)