### PR TITLE
feat!: command OFF in AUTO+COOL when current is in band

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,16 +329,63 @@ capacity even when temperature setpoint is met.
 ### Why HEAT does NOT need this fix
 
 Tested 2026-04-26 with HEAT in AUTO + room in band: **the unit
-properly idled its compressor**.  HEAT mode has no equivalent
-"always-on for dehumidification" reason to hold a min-frequency
-floor — humidity isn't being managed there.  HEAT mode also runs
-defrost cycles and other ambient-management logic that already
-includes true compressor idle as a steady state.
+properly idled its compressor**.
+
+The asymmetry is most likely **refrigerant-cycle direction**, not
+dehumidification.  An early hypothesis blamed COOL min-freq on
+internal humidity logic — the unit has a separate selectable Dry
+mode, COOL-only, which seemed to fit.  But Dry mode is *off* and
+COOL still floors, so dehumidification can't be the active driver.
+
+Better theory: in COOL the indoor coil is the cold sink, so when
+the compressor stops, refrigerant migrates to it.  On the next
+restart that liquid refrigerant can return to the compressor as a
+slug → bearing wear or shutdown.  Holding a minimum frequency
+prevents migration.  HEAT reverses the cycle (indoor coil is the
+hot side), so refrigerant migrates outdoors when stopped — benign,
+no slug risk on restart.  Compressor protection logic only needs
+to forbid full idle in COOL.
+
+The Dry-mode-COOL-only pairing is then explained simply by
+thermodynamics: dehumidification requires a cold coil to condense
+moisture, and only COOL gives you that.  It's not evidence about
+*how* COOL is controlled.
 
 So v2.0.0's "never command OFF" rule is *correct* for HEAT
-(start-up cost > min-freq idle cost) and *wrong* for COOL on this
-unit (min-freq pumps unwanted cold air).  v3 makes the correction
-asymmetric to match.
+(start-up cost > min-freq idle cost, no protection penalty) and
+*wrong* for COOL on this unit (min-freq pumps unwanted cold air).
+v3 makes the correction asymmetric to match.
+
+### Risk assessment
+
+Damage risk from cycling COOL on/off is **low**:
+
+- We use the manufacturer's `set_hvac_mode` service.  The unit's
+  firmware runs its own shutdown sequence (pump-down, valve
+  positioning) and startup sequence (soft-start ramp from low
+  frequency).  We're not yanking power.
+- Modern inverter units have built-in anti-short-cycle protection.
+  If the wrapper commands COOL within ~3-5 min of an OFF, the unit
+  queues the request internally.
+- Inverter compressors are far more cycle-tolerant than single-
+  stage; soft-start makes each cycle cheap in wear terms.
+- The OFF command we send is identical to what happens when a user
+  presses OFF on the wired thermostat — a normal manufacturer-
+  designed transition.
+
+Cumulative wear from extra cycling is real but minor (≈30 s of
+equivalent steady-state runtime per start).  The 2 °C band width
+in the Home preset should comfortably keep cycles under 2/hour in
+practice.
+
+Watch in live deployment:
+
+1. **Cycle frequency.** > 6 starts/hour sustained → add
+   `OFF_HOLD_UP` (Future Work #2 below).
+2. **Compressor restart frequency curve.** Healthy restart starts
+   low and ramps over ~30-60 s.  If `compressor_freq` jumps
+   straight to high, soft-start isn't engaging; revisit.
+3. **Protection trip codes** in HA logs after the first weeks.
 
 ### Implemented behavior (v3.0.0)
 
@@ -396,7 +443,37 @@ edges (sub-10-minute on/off cycles), add:
   re-arming COOL.  Prevents re-starting the compressor the moment
   current grazes the high edge.
 
-### 3. Wide-deadband HEAT (DEFERRED — empirically not needed)
+### 3. OFF on wrong-side COOL excursion (CANDIDATE)
+
+v3.0.0 deliberately keeps v2.0.0 behavior in the wrong-side COOL
+case: COOL committed + current < low → send COOL (and let
+`FLIP_DWELL` flip the committed direction to HEAT after 30 min).
+Per user direction at PR time: *"OFF only when tending to cool
+inside the band"*.
+
+The downside surfaces on cool spring/fall nights after a warm day:
+AUTO is still committed COOL from the afternoon, the room drifts
+below low overnight, and the wrapper sends COOL into a cold room
+for up to 30 minutes before the dwell-flip kicks in.  Empirically
+small (the unit modulates and the room is already cold so the
+gradient is small), but visible in logs.
+
+If this turns out to matter in the live deployment, the surgical
+fix is:
+
+```python
+if self._auto_mode == HVACMode.COOL:
+    if low <= inside <= high:
+        return HVACMode.OFF
+    if inside < low:           # NEW: don't fight the room
+        return HVACMode.OFF
+    return HVACMode.COOL
+```
+
+Decision deferred until we have overnight data showing the
+behavior is actually a problem.
+
+### 4. Wide-deadband HEAT (DEFERRED — empirically not needed)
 
 Originally proposed as a mirror of the COOL trigger.  Live testing
 2026-04-26 showed HEAT properly idles, so this is not implemented

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,124 +302,115 @@ downstream reads it.
   sensor's `last_state` is read immediately so the AUTO algorithm
   doesn't run on a stale value during the swap.
 
-## Future Work — Deliberate OFF refinement (refines v2.0.0 contract)
+## v3.0.0 — Deliberate OFF in AUTO+COOL (asymmetric, narrow scope)
 
-> **Status:** design idea, not implemented. Born from a 2026-04-26
-> diagnostic session that established the v2.0.0 "never command OFF in
-> AUTO" rule actively wastes energy in wide-deadband situations on
-> Midea inverter heat pumps.
+> **Status:** implemented in v3.0.0 (PR #58).  Refines the v2.0.0
+> "never command OFF in AUTO" contract, but only for the case where
+> empirical evidence showed it actively wastes energy.
 
 ### What we observed
 
 With smart_climate in AUTO, `current = 21.5 °C`, `target = 25 °C`
-(home preset, low/high = 21/23 → midpoint 22), COOL committed:
+(home preset, low/high = 21/23 → midpoint 22), **COOL committed**:
 
 - Midea unit kept compressor at minimum frequency continuously.
 - `compressor_flags = 0x80 ACTIVE`, `compressor_freq` non-zero,
   `t2b` (indoor coil outlet) pinned at 16.5–17.5 °C indefinitely.
-- Vents pushed ~19 °C air into rooms that were already 3 °C below
-  target. Reproduced identically with both XYE and the factory
-  wired thermostat — confirming this is **Midea unit behavior**, not
-  XYE/wrapper bug.
+- Vents pushed ~14 °C air into rooms that were already 3 °C below
+  target.  Reproduced identically with both XYE and the factory
+  wired thermostat — **Midea unit behavior**, not wrapper bug.
 
-This is the **inverter minimum-frequency floor**: Midea inverters in
-COOL mode at low load don't idle the compressor; they hold at the
-lowest sustainable frequency. Generic-thermostat assumptions (idle
-when current << setpoint) don't hold.
+This is the **COOL minimum-frequency floor**: Midea inverters in
+COOL mode at low load don't idle the compressor.  Likely cause is
+the unit's internal dehumidification logic — many inverter ACs hold
+a minimum compressor speed in COOL to maintain dehumidification
+capacity even when temperature setpoint is met.
 
-### The vicious cycle this creates
+### Why HEAT does NOT need this fix
 
-Without deliberate OFF, an inverter heat pump in COOL mode at low
-load runs a self-defeating loop:
+Tested 2026-04-26 with HEAT in AUTO + room in band: **the unit
+properly idled its compressor**.  HEAT mode has no equivalent
+"always-on for dehumidification" reason to hold a min-frequency
+floor — humidity isn't being managed there.  HEAT mode also runs
+defrost cycles and other ambient-management logic that already
+includes true compressor idle as a steady state.
 
-1. Room is already below setpoint, no cooling needed.
-2. Compressor holds at minimum frequency anyway → continues to
-   over-cool the room.
-3. Room drifts further below comfort range; HVAC eventually has to
-   transition to HEAT mode (or user complains, raises target).
-4. Heat pump now runs in heating to recover the heat that was
-   needlessly removed in step 2.
-5. Once warm again, room re-enters the upper part of the band,
-   AUTO commits back to COOL, and step 1 repeats.
+So v2.0.0's "never command OFF" rule is *correct* for HEAT
+(start-up cost > min-freq idle cost) and *wrong* for COOL on this
+unit (min-freq pumps unwanted cold air).  v3 makes the correction
+asymmetric to match.
 
-Two compressor stages — cooling then heating — to net zero benefit.
-That's the energy waste the user observed: paying continuously to
-cool, then paying again to undo that cooling. The deliberate-OFF
-design breaks the loop at step 2 by stopping the compressor when
-the room is already where it should be (or beyond).
+### Implemented behavior (v3.0.0)
 
-### Why v2.0.0's "never OFF" wastes energy here
+Sticky AUTO commitment from v2.0.0 is unchanged.  The only change
+is in the unit command derived from the committed direction:
 
-| Scenario | Compressor power | Effect |
-|----------|-----------------|--------|
-| v2.0.0 (today): stay sticky, run min-freq | ~150 W continuous | Over-cools below band; pays a future heating bill to recover |
-| Proposed: deliberate OFF in wide deadband | ~30 W idle, restart 1–2× per cycle | ~3.5× less average power, no over-cooling, no recovery debt |
+| `_auto_mode` | `current` vs `[low, high]` | Unit command |
+|--------------|---------------------------|--------------|
+| HEAT         | (any)                     | HEAT (v2.0.0 unchanged) |
+| COOL         | in band                   | **OFF** |
+| COOL         | above high                | COOL (v2.0.0) |
+| COOL         | below low                 | COOL (v2.0.0; FLIP_DWELL flips to HEAT) |
 
-The "never OFF" reasoning was correct *as a default* — repeated
-short-cycling does waste energy on an inverter (each start = 3–5×
-steady-state power for ~30 s of inrush). But the rule fails when
-running at minimum produces *unwanted* output. Deliberate, infrequent
-OFFs amortise the start cost across long stretches.
+`hvac_action` returns `IDLE` (not `OFF`) on the wrapper whenever
+the unit_command is OFF — distinguishes "AUTO resting" from
+"user turned it off entirely".  Implemented via a `_unit_command`
+attribute set by `_async_sync_real_climate` and read by the
+`hvac_action` property.
 
-### Three OFF triggers (preserves sticky AUTO)
-
-The sticky-AUTO commitment from v2.0.0 stays. We're **not** flapping
-the *committed* mode. We insert OFF as a *unit-level* state under
-specific conditions:
-
-1. **Mode-flip transition.** When AUTO has decided to flip
-   (FLIP_DWELL met, opposite-side dwell timer expired): emit
-   `cool → off → wait OFF_SETTLE → heat` (and mirror). Lets the
-   compressor spin down + reversing valve stabilise + refrigerant
-   pressures equalise before the new mode kicks in. Default
-   `OFF_SETTLE = 60 s`. At most ~1–2 mode flips/day in normal use,
-   so the energy cost of one extra startup is negligible.
-
-2. **Wide-deadband in COOL.** Current is more than `OFF_DEADBAND`
-   (default `1.5 × FLIP_MARGIN ≈ 0.75 °C`) **below** the low setpoint
-   for at least `OFF_HOLD_DOWN` (default 60 s of sustained excursion):
-   command OFF, hold OFF until current rises back to the low
-   setpoint, then resume COOL. Cycle = `cool → off → cool`.
-
-3. **Wide-deadband in HEAT.** Mirror: current more than
-   `OFF_DEADBAND` **above** the high setpoint, sustained, → command
-   OFF; hold OFF until current drops back to the high setpoint;
-   resume HEAT. Cycle = `heat → off → heat`.
-
-Inside the deadband (`current ∈ [low, high]` and within FLIP_MARGIN
-of midpoint) the v2.0.0 sticky-min-frequency behavior is unchanged —
-that case is where "stay at minimum" is genuinely the right choice.
-
-### Anti-flapping guards
-
-- `OFF_HOLD_DOWN` (sustained-excursion threshold) prevents brief
-  sensor jitter from triggering OFF. If the inside reading bounces
-  past the deadband for 5 s and back, no OFF.
-- `OFF_HOLD_UP` (minimum OFF duration, default 5 min) prevents
-  re-arming the mode the moment current grazes the band edge.
-  Compressor restarts at most once every few minutes worst case.
-- AUTO stays committed throughout — even if we're in `cool → off`,
-  `_auto_mode` is still COOL. The dwell timer for heat/cool flipping
-  only runs when in non-OFF state, so OFF stretches don't accelerate
-  a flip.
-
-### Constants to add
-
-```python
-# const.py additions
-OFF_SETTLE      = 60     # seconds, mode-flip OFF duration
-OFF_DEADBAND    = 0.75   # °C past band edge before OFF triggers
-OFF_HOLD_DOWN   = 60     # seconds of sustained excursion before OFF
-OFF_HOLD_UP     = 300    # minimum OFF duration before re-arming mode
-```
+No anti-flap guards yet.  We deliberately shipped the simplest
+possible thing first (just a band check, no `OFF_HOLD_DOWN`,
+`OFF_HOLD_UP`, or `OFF_DEADBAND`).  If the live deployment shows
+short-cycling at the band edges, those guards are next — see
+"Future Work" below.
 
 ### Integration with the per-preset inside-sensor work
 
-Both refinements share one substrate: smart_climate's
-`current_temperature` (whatever sensor the active preset points at)
-drives all decisions. The per-preset sensor work changes *which*
-sensor; the deliberate-OFF work changes *what to do* with the value.
-They compose cleanly — implement either order.
+Both share one substrate: smart_climate's `current_temperature`
+(whatever sensor the active preset points at) drives all decisions.
+The per-preset sensor work changes *which* sensor; the deliberate-OFF
+work changes *what to do* with the value.  Compose cleanly.
+
+## Future Work — Deliberate-OFF refinements (not yet implemented)
+
+The v3.0.0 implementation is intentionally minimal.  These refinements
+are scoped but not built:
+
+### 1. Mode-flip transition OFF
+
+When AUTO commits a HEAT↔COOL flip (FLIP_DWELL met), emit
+`old_mode → off → wait OFF_SETTLE → new_mode`.  Lets the compressor
+spin down, the reversing valve stabilise, and refrigerant pressures
+equalise before the new mode kicks in.  At most ~1–2 mode flips/day
+in normal use, so the cost of an extra startup is negligible.
+Default `OFF_SETTLE = 60 s`.
+
+### 2. COOL-side anti-flap guards
+
+If the live data shows the COOL unit short-cycling at the band
+edges (sub-10-minute on/off cycles), add:
+
+- `OFF_HOLD_DOWN` (default 60 s): require a sustained in-band
+  reading before triggering OFF.  Filters sensor jitter.
+- `OFF_HOLD_UP` (default 300 s): minimum OFF duration before
+  re-arming COOL.  Prevents re-starting the compressor the moment
+  current grazes the high edge.
+
+### 3. Wide-deadband HEAT (DEFERRED — empirically not needed)
+
+Originally proposed as a mirror of the COOL trigger.  Live testing
+2026-04-26 showed HEAT properly idles, so this is not implemented
+and not on the roadmap unless a different unit shows the symmetric
+defect.
+
+### Constants reserved for future use
+
+```python
+# const.py additions, when refinements are needed
+OFF_SETTLE     = 60     # seconds, mode-flip OFF duration
+OFF_HOLD_DOWN  = 60     # seconds in band before OFF (anti-jitter)
+OFF_HOLD_UP    = 300    # minimum OFF duration before re-arming COOL
+```
 
 ## Future Work — Fan time percentage (Ecobee-style)
 

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -489,28 +489,27 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
 
         In AUTO mode the wrapper maintains a sticky **committed direction**
         (HEAT or COOL) using v2.0.0's FLIP_DWELL/FLIP_MARGIN logic — same
-        as before:
-        - First entry: pick HEAT or COOL based on outside sensor (or
-          inside-vs-midpoint with no outside sensor).  Tie-breaks to COOL.
-        - Subsequent ticks: keep the committed direction; only flip after
-          inside has been past midpoint by FLIP_MARGIN against the committed
-          direction for FLIP_DWELL seconds (with the dead-zone hysteresis
-          that doesn't reset the timer in the buffer area).
+        as before.  The **unit command** sent to the real device is then
+        derived asymmetrically by committed direction:
 
-        The **unit command** sent to the real device is then derived from
-        current vs the comfort band, *regardless* of committed direction:
+        **Committed HEAT** — return HEAT unconditionally (v2.0.0 contract
+        unchanged).  The Midea unit modulates its compressor down to true
+        idle in HEAT when the room is at setpoint, so continuous HEAT at
+        min modulation costs less than OFF/ON cycling.
 
+        **Committed COOL** — narrow, surgical change vs. v2.0.0.  The
+        *only* deviation from v2.0.0 is in-band:
         - `current ∈ [low, high]`  →  **OFF** (no work needed)
-        - committed COOL & `current > high`  →  COOL  (room hot, do work)
-        - committed HEAT & `current < low`   →  HEAT  (room cold, do work)
-        - wrong-side excursion (committed direction opposite to demand)
-          →  OFF, FLIP_DWELL timer counts toward direction flip
+        - `current > high`         →  COOL  (v2.0.0)
+        - `current < low`          →  COOL  (v2.0.0; FLIP_DWELL flips
+                                     committed direction to HEAT)
 
-        This refines v2.0.0's "never OFF in AUTO" rule.  v2.0.0 assumed the
-        underlying device would idle the compressor at min modulation when
-        in band; on Midea inverter heat pumps that's false — they have a
-        minimum-frequency floor and hold the compressor running.  v3 lets
-        the wrapper provide the idle by commanding OFF directly.
+        Why only here: on this Midea unit the COOL mode holds a minimum-
+        frequency floor and keeps pushing 12-14 °C supply air into rooms
+        that are already in band — diagnosed empirically 2026-04-25.  HEAT
+        does not have this defect, and COOL outside the band still has
+        real demand to chase.  The wrong-side COOL case (below low) is
+        rare and the existing 30-min dwell flip handles it.
         """
         if self._hvac_mode == HVACMode.OFF:
             return HVACMode.OFF
@@ -557,18 +556,17 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         elif right_side:
             self._pending_flip_since = None
 
-        # Unit command from current vs band.  OFF inside the band; the
-        # committed direction's active mode only outside the band on the
-        # corresponding side.  Wrong-side excursions return OFF (don't fight
-        # the room while the dwell timer counts toward a flip).
+        # Unit command — asymmetric between committed directions.
+        # COOL: in-band → OFF; outside band → COOL (matches v2.0.0
+        # everywhere except the in-band case where the Midea min-frequency
+        # floor wastes energy).
+        # HEAT: always HEAT (v2.0.0 contract unchanged; the unit modulates
+        # to true idle in HEAT when no demand).
         if self._auto_mode == HVACMode.COOL:
-            if inside > high:
-                return HVACMode.COOL
-            return HVACMode.OFF
-        else:  # HEAT committed
-            if inside < low:
-                return HVACMode.HEAT
-            return HVACMode.OFF
+            if low <= inside <= high:
+                return HVACMode.OFF
+            return HVACMode.COOL
+        return HVACMode.HEAT
 
     # ------------------------------------------------------------------
     # Real-climate synchronisation

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -165,6 +165,12 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # _auto_mode once it has been set continuously for FLIP_DWELL.
         self._pending_flip_since: datetime.datetime | None = None
 
+        # Last unit command (HEAT/COOL/OFF) the wrapper computed for the
+        # real device.  Used by the hvac_action property to surface IDLE
+        # while in AUTO + deliberate-OFF (inside the comfort band) so the
+        # frontend distinguishes "AUTO resting" from "user turned it off".
+        self._unit_command: HVACMode | None = None
+
     # ------------------------------------------------------------------
     # ClimateEntity properties
     # ------------------------------------------------------------------
@@ -186,7 +192,19 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
 
     @property
     def hvac_action(self) -> HVACAction | None:
-        """Return the current running HVAC action (mirrored from real device)."""
+        """Return the current running HVAC action.
+
+        In AUTO mode, when the wrapper has commanded the real device OFF
+        (deliberate-OFF inside the comfort band), surface IDLE so the
+        frontend distinguishes "AUTO resting between calls for work" from
+        "user turned the thermostat off entirely".  Otherwise mirror the
+        real device's reported action.
+        """
+        if (
+            self._hvac_mode == HVACMode.AUTO
+            and self._unit_command == HVACMode.OFF
+        ):
+            return HVACAction.IDLE
         return self._hvac_action
 
     @property
@@ -469,22 +487,30 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
 
         For non-AUTO modes the user's choice is passed through.
 
-        In AUTO mode:
-        1. If no mode has been chosen yet, pick HEAT or COOL once based on
-           the outside sensor (or inside-vs-midpoint when no outside sensor
-           is configured).  Tie-break to COOL.
-        2. Otherwise stick with the previously-committed mode regardless of
-           where the inside temperature sits — the (modulating) real device
-           is expected to settle on the band midpoint.
-        3. Flip to the opposite mode only when the inside temperature has
-           been continuously past the midpoint by FLIP_MARGIN against the
-           committed mode for FLIP_DWELL seconds.  The dwell timer is reset
-           only when the temperature crosses fully back to the correct side
-           of the midpoint, so jitter near the FLIP_MARGIN threshold doesn't
-           keep stalling the flip.
+        In AUTO mode the wrapper maintains a sticky **committed direction**
+        (HEAT or COOL) using v2.0.0's FLIP_DWELL/FLIP_MARGIN logic — same
+        as before:
+        - First entry: pick HEAT or COOL based on outside sensor (or
+          inside-vs-midpoint with no outside sensor).  Tie-breaks to COOL.
+        - Subsequent ticks: keep the committed direction; only flip after
+          inside has been past midpoint by FLIP_MARGIN against the committed
+          direction for FLIP_DWELL seconds (with the dead-zone hysteresis
+          that doesn't reset the timer in the buffer area).
 
-        AUTO never returns OFF — the real device is left running at low
-        modulation rather than being repeatedly start/stop cycled.
+        The **unit command** sent to the real device is then derived from
+        current vs the comfort band, *regardless* of committed direction:
+
+        - `current ∈ [low, high]`  →  **OFF** (no work needed)
+        - committed COOL & `current > high`  →  COOL  (room hot, do work)
+        - committed HEAT & `current < low`   →  HEAT  (room cold, do work)
+        - wrong-side excursion (committed direction opposite to demand)
+          →  OFF, FLIP_DWELL timer counts toward direction flip
+
+        This refines v2.0.0's "never OFF in AUTO" rule.  v2.0.0 assumed the
+        underlying device would idle the compressor at min modulation when
+        in band; on Midea inverter heat pumps that's false — they have a
+        minimum-frequency floor and hold the compressor running.  v3 lets
+        the wrapper provide the idle by commanding OFF directly.
         """
         if self._hvac_mode == HVACMode.OFF:
             return HVACMode.OFF
@@ -506,12 +532,12 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
                 ref = inside
             self._auto_mode = HVACMode.HEAT if ref < mid else HVACMode.COOL
             self._pending_flip_since = None
-            return self._auto_mode
+            # fall through to the band-aware unit-command logic below
 
-        # Flip evaluation.  Wrong-side / right-side bands have a deadzone
-        # in between (mid ± FLIP_MARGIN) where the timer keeps running but
-        # is not reset, so sensor jitter near the margin doesn't repeatedly
-        # cancel an in-progress flip.
+        # Sticky direction-flip evaluation (unchanged from v2.0.0).  Wrong-
+        # side / right-side bands have a deadzone in between (mid ± FLIP_MARGIN)
+        # where the timer keeps running but is not reset, so sensor jitter
+        # near the margin doesn't repeatedly cancel an in-progress flip.
         if self._auto_mode == HVACMode.COOL:
             wrong_side = inside <= mid - FLIP_MARGIN
             right_side = inside >= mid
@@ -531,7 +557,18 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         elif right_side:
             self._pending_flip_since = None
 
-        return self._auto_mode
+        # Unit command from current vs band.  OFF inside the band; the
+        # committed direction's active mode only outside the band on the
+        # corresponding side.  Wrong-side excursions return OFF (don't fight
+        # the room while the dwell timer counts toward a flip).
+        if self._auto_mode == HVACMode.COOL:
+            if inside > high:
+                return HVACMode.COOL
+            return HVACMode.OFF
+        else:  # HEAT committed
+            if inside < low:
+                return HVACMode.HEAT
+            return HVACMode.OFF
 
     # ------------------------------------------------------------------
     # Real-climate synchronisation
@@ -543,6 +580,10 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             return
 
         real_mode = self._desired_real_mode()
+        # Record the wrapper's intent so hvac_action can surface IDLE for
+        # deliberate-OFF (AUTO + OFF inside the comfort band) without
+        # re-running _desired_real_mode (which has timer side-effects).
+        self._unit_command = real_mode
 
         real_state = self.hass.states.get(self._real_climate_id)
         if real_state is None:
@@ -550,10 +591,12 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
 
         current_mode = real_state.state
 
-        # OFF is only reachable here when the user commanded smart climate
-        # OFF after a sensor callback was already queued — AUTO never
-        # returns OFF.  Forward the OFF; only send the command if the real
-        # device isn't already off.
+        # OFF reaches here in two cases now: (a) the user commanded smart
+        # climate OFF, and (b) AUTO is in deliberate-OFF — the wrapper
+        # provides the idle state Midea inverters can't (their HEAT/COOL
+        # modes hold a min-frequency floor instead of truly idling).
+        # Forward the OFF; only send the command if the real device isn't
+        # already off.
         if real_mode == HVACMode.OFF:
             if current_mode != HVACMode.OFF.value:
                 await self.hass.services.async_call(

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -162,64 +162,263 @@ class TestDesiredRealMode:
         assert entity._desired_real_mode() == HVACMode.COOL
 
     def test_initial_pick_uses_outside_when_cold(self):
-        """Outside sensor decides the first commitment: cold → HEAT."""
+        """Outside sensor decides the first commitment: cold → HEAT.
+
+        v3: in-band current returns OFF as the unit command, but the
+        commitment side-effect on _auto_mode still fires.
+        """
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         entity = self._entity(inside=mid, outside=DEFAULT_HOME_MIN - 5)
-        assert entity._desired_real_mode() == HVACMode.HEAT
+        entity._desired_real_mode()
         assert entity._auto_mode == HVACMode.HEAT
 
     def test_initial_pick_uses_outside_when_warm(self):
         """Outside sensor decides the first commitment: warm → COOL."""
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         entity = self._entity(inside=mid, outside=DEFAULT_HOME_MAX + 5)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
         assert entity._auto_mode == HVACMode.COOL
 
     def test_initial_pick_falls_back_to_inside_when_no_outside(self):
         """No outside sensor: inside-vs-midpoint chooses initial mode."""
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         cold = self._entity(inside=mid - 1.0)
-        assert cold._desired_real_mode() == HVACMode.HEAT
+        cold._desired_real_mode()
+        assert cold._auto_mode == HVACMode.HEAT
         warm = self._entity(inside=mid + 1.0)
-        assert warm._desired_real_mode() == HVACMode.COOL
+        warm._desired_real_mode()
+        assert warm._auto_mode == HVACMode.COOL
 
     def test_initial_pick_at_midpoint_breaks_to_cool(self):
         """Tie at exactly the midpoint with no outside sensor → COOL."""
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         entity = self._entity(inside=mid)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
 
     def test_auto_below_low_picks_heat(self):
-        """Way below the band — initial pick is HEAT (inside fallback)."""
+        """Way below the band — initial pick is HEAT and unit runs HEAT."""
         entity = self._entity(inside=DEFAULT_HOME_MIN - 1)
         assert entity._desired_real_mode() == HVACMode.HEAT
+        assert entity._auto_mode == HVACMode.HEAT
 
     def test_auto_above_high_picks_cool(self):
-        """Way above the band — initial pick is COOL."""
+        """Way above the band — initial pick is COOL and unit runs COOL."""
         entity = self._entity(inside=DEFAULT_HOME_MAX + 1)
         assert entity._desired_real_mode() == HVACMode.COOL
+        assert entity._auto_mode == HVACMode.COOL
 
-    def test_auto_never_returns_off(self):
-        """Smoke test: across a sweep of inside temps in AUTO, OFF is never
-        returned regardless of starting commitment."""
-        for inside in [
-            DEFAULT_HOME_MIN - 5,
-            DEFAULT_HOME_MIN,
-            (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2,
-            DEFAULT_HOME_MAX,
-            DEFAULT_HOME_MAX + 5,
-        ]:
-            for prior in (None, HVACMode.HEAT, HVACMode.COOL):
+    def test_auto_returns_off_when_inside_band(self):
+        """v3 contract — supersedes v2.0.0's "never returns OFF" rule.
+
+        Inside the comfort band (current ∈ [low, high]), AUTO returns OFF
+        regardless of committed direction. The Midea inverter cannot truly
+        idle inside an active mode; commanding OFF is the only way to stop
+        the compressor when no work is needed.
+
+        Outside the band, the committed direction is honoured: above high
+        with COOL committed → COOL; below low with HEAT committed → HEAT.
+        Wrong-side excursions (committed mode opposite to the demand)
+        return OFF until the FLIP_DWELL/FLIP_MARGIN logic flips the
+        committed direction.
+        """
+        low, high = DEFAULT_HOME_MIN, DEFAULT_HOME_MAX
+        # Inside the band: always OFF, regardless of committed direction
+        for inside in [low, low + 0.5, (low + high) / 2, high - 0.5, high]:
+            for prior in (HVACMode.HEAT, HVACMode.COOL):
                 entity = self._entity(inside=inside)
                 entity._auto_mode = prior
-                assert entity._desired_real_mode() != HVACMode.OFF
+                assert entity._desired_real_mode() == HVACMode.OFF, (
+                    f"current={inside} in [{low},{high}], committed={prior}: "
+                    f"expected OFF, got {entity._desired_real_mode()}"
+                )
+
+        # Outside the band, the committed direction matters
+        cool_committed_above = self._entity(inside=high + 1)
+        cool_committed_above._auto_mode = HVACMode.COOL
+        assert cool_committed_above._desired_real_mode() == HVACMode.COOL
+
+        heat_committed_below = self._entity(inside=low - 1)
+        heat_committed_below._auto_mode = HVACMode.HEAT
+        assert heat_committed_below._desired_real_mode() == HVACMode.HEAT
+
+        # Wrong-side excursions: OFF (don't fight; flip dwell ticks)
+        cool_committed_below = self._entity(inside=low - 1)
+        cool_committed_below._auto_mode = HVACMode.COOL
+        assert cool_committed_below._desired_real_mode() == HVACMode.OFF
+
+        heat_committed_above = self._entity(inside=high + 1)
+        heat_committed_above._auto_mode = HVACMode.HEAT
+        assert heat_committed_above._desired_real_mode() == HVACMode.OFF
+
+
+class TestAutoOffInBand:
+    """OFF as a peer state with HEAT/COOL in AUTO mode.
+
+    Replaces the v2.0.0 "never command OFF in AUTO" contract. On Midea
+    inverter heat pumps the wrapper has to provide the idle state itself,
+    because the unit's COOL/HEAT modes don't truly idle the compressor —
+    they hold at a minimum-frequency floor. Diagnosed empirically on
+    2026-04-26 by reproducing the same over-cooling under both XYE and
+    the factory wired thermostat.
+    """
+
+    def _entity(self, inside, low=21.0, high=23.0, committed=HVACMode.COOL):
+        """Build a SmartClimateEntity in AUTO mode with custom band."""
+        hass = _make_hass_mock(inside_temp=inside)
+        config = {
+            CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
+            CONF_INSIDE_SENSOR: INSIDE_SENSOR_ID,
+        }
+        entity = _make_entity(hass, config)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_HOME
+        entity._current_temperature = inside
+        # Override Home preset's range for this test
+        entity._preset_ranges[PRESET_HOME] = (low, high)
+        entity._auto_mode = committed
+        return entity
+
+    def test_overnight_in_band_traversal_stays_off(self):
+        """Reproduces the 2026-04-25 overnight observation.
+
+        The room stayed in [21, 23] for the entire night (10 h, 1812
+        whole_home_temperature samples, every value 21.2 ≤ t ≤ 22.8).
+        v2.0.0 ran heat→cool→heat→cool cycles all night anyway because
+        of the 'never OFF' rule and the inverter min-frequency floor.
+
+        New behaviour: OFF the entire time, regardless of which direction
+        AUTO has committed to. Compressor stops, room drifts naturally
+        within the band, no useless cooling-then-heating cycles.
+        """
+        # Sample of actual overnight currents from the diagnostic session
+        overnight_currents = [
+            21.5, 21.7, 22.0, 22.6, 22.7, 22.5,
+            21.4, 21.5, 21.3, 22.6, 22.5, 21.4, 21.3,
+            22.6, 22.5, 21.4, 22.5, 21.5, 21.7,
+        ]
+        for committed in (HVACMode.HEAT, HVACMode.COOL):
+            for current in overnight_currents:
+                entity = self._entity(
+                    inside=current, low=21.0, high=23.0, committed=committed,
+                )
+                assert entity._desired_real_mode() == HVACMode.OFF, (
+                    f"OVERNIGHT-BUG REGRESSION: current={current} "
+                    f"(in [21, 23]), committed={committed} should be OFF "
+                    f"but got {entity._desired_real_mode()}. The Midea "
+                    f"inverter min-frequency floor wastes energy if AUTO "
+                    f"doesn't OFF in-band."
+                )
+
+    def test_in_band_yields_off_for_both_committed_directions(self):
+        """Tighter point-tests covering the band edges and midpoint."""
+        for inside in (21.0, 21.5, 22.0, 22.5, 23.0):
+            for committed in (HVACMode.HEAT, HVACMode.COOL):
+                entity = self._entity(inside=inside, committed=committed)
+                assert entity._desired_real_mode() == HVACMode.OFF
+
+    def test_above_high_with_cool_committed_runs_cool(self):
+        """Outside band on the right side: do work."""
+        entity = self._entity(inside=23.5, committed=HVACMode.COOL)
+        assert entity._desired_real_mode() == HVACMode.COOL
+
+    def test_below_low_with_heat_committed_runs_heat(self):
+        entity = self._entity(inside=20.5, committed=HVACMode.HEAT)
+        assert entity._desired_real_mode() == HVACMode.HEAT
+
+    def test_above_high_with_heat_committed_returns_off(self):
+        """Wrong-side excursion: OFF until FLIP_DWELL elapses."""
+        entity = self._entity(inside=23.5, committed=HVACMode.HEAT)
+        assert entity._desired_real_mode() == HVACMode.OFF
+
+    def test_below_low_with_cool_committed_returns_off(self):
+        entity = self._entity(inside=20.5, committed=HVACMode.COOL)
+        assert entity._desired_real_mode() == HVACMode.OFF
+
+
+class TestHvacActionInAutoOff:
+    """hvac_action exposes IDLE in deliberate-OFF (AUTO + in-band).
+
+    The real Midea unit, when commanded OFF, reports hvac_action='off'.
+    The wrapper hides that and surfaces IDLE instead so the user sees
+    "AUTO is resting between calls for work" rather than the alarming
+    "thermostat is OFF" — which usually signals a manual user override.
+    Outside the deliberate-OFF state, hvac_action mirrors the real
+    device's reported action verbatim.
+    """
+
+    def _entity(self, inside, low=21.0, high=23.0, committed=HVACMode.COOL):
+        hass = _make_hass_mock(inside_temp=inside)
+        config = {
+            CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
+            CONF_INSIDE_SENSOR: INSIDE_SENSOR_ID,
+        }
+        entity = _make_entity(hass, config)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_HOME
+        entity._current_temperature = inside
+        entity._preset_ranges[PRESET_HOME] = (low, high)
+        entity._auto_mode = committed
+        return entity
+
+    @pytest.mark.asyncio
+    async def test_idle_when_auto_in_band(self):
+        """AUTO + in-band → wrapper sends OFF → hvac_action == IDLE."""
+        entity = self._entity(inside=22.0)  # mid of [21, 23]
+        # Real device will be commanded OFF and report 'off' back to us.
+        entity._hvac_action = HVACAction.OFF
+        await entity._async_sync_real_climate()
+        assert entity._unit_command == HVACMode.OFF
+        assert entity.hvac_action == HVACAction.IDLE
+
+    @pytest.mark.asyncio
+    async def test_mirrors_cooling_when_above_high(self):
+        """AUTO + above-high + COOL committed → unit runs COOL → mirror."""
+        entity = self._entity(inside=23.5, committed=HVACMode.COOL)
+        entity._hvac_action = HVACAction.COOLING  # mirrored from real
+        await entity._async_sync_real_climate()
+        assert entity._unit_command == HVACMode.COOL
+        assert entity.hvac_action == HVACAction.COOLING
+
+    @pytest.mark.asyncio
+    async def test_mirrors_heating_when_below_low(self):
+        """AUTO + below-low + HEAT committed → unit runs HEAT → mirror."""
+        entity = self._entity(inside=20.5, committed=HVACMode.HEAT)
+        entity._hvac_action = HVACAction.HEATING
+        await entity._async_sync_real_climate()
+        assert entity._unit_command == HVACMode.HEAT
+        assert entity.hvac_action == HVACAction.HEATING
+
+    def test_user_off_mode_shows_off_not_idle(self):
+        """User-commanded OFF must read OFF, not IDLE — IDLE is reserved
+        for AUTO's deliberate in-band rest."""
+        entity = self._entity(inside=22.0)
+        entity._hvac_mode = HVACMode.OFF  # user turned it off
+        entity._unit_command = HVACMode.OFF
+        entity._hvac_action = HVACAction.OFF
+        assert entity.hvac_action == HVACAction.OFF
+
+    def test_initial_state_no_unit_command_passes_through(self):
+        """Before the first sync runs, _unit_command is None — fall
+        through to whatever the real device last reported."""
+        entity = self._entity(inside=22.0)
+        entity._unit_command = None
+        entity._hvac_action = HVACAction.COOLING
+        assert entity.hvac_action == HVACAction.COOLING
 
 
 class TestStickyAutoMode:
-    """Sticky-mode behaviour: a committed HEAT/COOL choice survives jitter
-    and only flips after FLIP_DWELL seconds continuously past the midpoint
-    by FLIP_MARGIN against the committed mode (the room is asking for the
-    opposite mode, not just sitting near the boundary).
+    """Sticky **committed direction** behaviour: a committed HEAT/COOL
+    choice survives jitter and only flips after FLIP_DWELL seconds
+    continuously past the midpoint by FLIP_MARGIN against the committed
+    mode (the room is asking for the opposite mode, not just sitting near
+    the boundary).
+
+    These tests assert ``_auto_mode`` (the committed direction) — not
+    ``_desired_real_mode()``, which under v3 returns OFF anywhere inside
+    the comfort band regardless of what direction is committed.  The
+    sticky-direction logic and the unit-command logic are independent
+    layers; this class covers the former.
     """
 
     def _entity(self, inside: float, committed: HVACMode):
@@ -244,12 +443,14 @@ class TestStickyAutoMode:
     def test_cool_stays_cool_above_midpoint(self):
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         entity = self._entity(inside=mid + 0.5, committed=HVACMode.COOL)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
 
     def test_heat_stays_heat_below_midpoint(self):
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         entity = self._entity(inside=mid - 0.5, committed=HVACMode.HEAT)
-        assert entity._desired_real_mode() == HVACMode.HEAT
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.HEAT
 
     def test_cool_survives_jitter_above_low_edge(self):
         """COOL committed; inside jittering at the low band edge does not
@@ -260,7 +461,8 @@ class TestStickyAutoMode:
         # it — i.e. still on the right side / dead-zone boundary.
         entity = self._entity(inside=mid - FLIP_MARGIN + 0.01, committed=HVACMode.COOL)
         for _ in range(5):
-            assert entity._desired_real_mode() == HVACMode.COOL
+            entity._desired_real_mode()
+            assert entity._auto_mode == HVACMode.COOL
 
     def test_cool_does_not_flip_briefly_past_margin(self):
         """COOL committed; a few sensor ticks past the wrong-side margin
@@ -270,20 +472,23 @@ class TestStickyAutoMode:
         now, advance = _fake_clock()
         entity._now = now
         # First tick: starts the dwell timer.
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
         assert entity._pending_flip_since is not None
         # Just under the dwell threshold: still COOL.
         advance(FLIP_DWELL - 1)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
 
     def test_cool_flips_to_heat_after_dwell(self):
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         entity = self._entity(inside=mid - FLIP_MARGIN - 0.1, committed=HVACMode.COOL)
         now, advance = _fake_clock()
         entity._now = now
-        assert entity._desired_real_mode() == HVACMode.COOL  # arms timer
+        entity._desired_real_mode()  # arms timer
+        assert entity._auto_mode == HVACMode.COOL
         advance(FLIP_DWELL)
-        assert entity._desired_real_mode() == HVACMode.HEAT
+        entity._desired_real_mode()
         assert entity._auto_mode == HVACMode.HEAT
         assert entity._pending_flip_since is None
 
@@ -292,9 +497,11 @@ class TestStickyAutoMode:
         entity = self._entity(inside=mid + FLIP_MARGIN + 0.1, committed=HVACMode.HEAT)
         now, advance = _fake_clock()
         entity._now = now
-        assert entity._desired_real_mode() == HVACMode.HEAT
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.HEAT
         advance(FLIP_DWELL)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
 
     def test_dwell_resets_on_full_crossback_to_correct_side(self):
         """COOL committed, inside drops below the wrong-side margin then
@@ -304,22 +511,26 @@ class TestStickyAutoMode:
         entity = self._entity(inside=mid - FLIP_MARGIN - 0.1, committed=HVACMode.COOL)
         now, advance = _fake_clock()
         entity._now = now
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
         assert entity._pending_flip_since is not None
 
         # Cross back fully to the correct (above-midpoint) side.
         advance(60)
         self._set(entity, mid + 0.5)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
         assert entity._pending_flip_since is None
 
         # Now drop below margin again — timer must restart from now,
         # a near-full-dwell wait must NOT flip.
         advance(60)
         self._set(entity, mid - FLIP_MARGIN - 0.1)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
         advance(FLIP_DWELL - 1)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
 
     def test_dwell_keeps_running_in_deadzone(self):
         """If inside drops past margin (arms timer) then drifts up into the
@@ -329,24 +540,28 @@ class TestStickyAutoMode:
         entity = self._entity(inside=mid - FLIP_MARGIN - 0.1, committed=HVACMode.COOL)
         now, advance = _fake_clock()
         entity._now = now
-        assert entity._desired_real_mode() == HVACMode.COOL  # arms timer
+        entity._desired_real_mode()  # arms timer
+        assert entity._auto_mode == HVACMode.COOL
         armed_at = entity._pending_flip_since
 
         # Drift up into the dead-zone (between mid - FLIP_MARGIN and mid):
         # neither wrong_side nor right_side, so timer state is preserved.
         advance(60)
         self._set(entity, mid - FLIP_MARGIN + 0.1)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
         assert entity._pending_flip_since == armed_at
 
         # Drop back past margin and let the original dwell complete.
         advance(60)
         self._set(entity, mid - FLIP_MARGIN - 0.1)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
         # Total elapsed since arm = 60 + 60 + remaining; advance just enough
         # to cross the dwell threshold.
         advance(FLIP_DWELL - 120)
-        assert entity._desired_real_mode() == HVACMode.HEAT
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.HEAT
 
 
 class TestLeavingAutoClearsCommitment:
@@ -744,12 +959,17 @@ class TestSyncedSetpoints:
         hass.services.async_call.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_sync_in_auto_never_sends_off(self):
-        """In AUTO the real device is never commanded OFF, even when inside
-        is squarely in the comfort band."""
+    async def test_sync_in_auto_sends_off_when_in_band(self):
+        """v3 contract — supersedes v2.0.0's "never OFF in AUTO" rule.
+
+        Inside the comfort band the wrapper commands the real device OFF
+        so the Midea inverter actually idles instead of holding its
+        minimum-frequency floor and pumping conditioned air the room
+        doesn't need.
+        """
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         hass = _make_hass_mock(
-            real_climate_state=HVACMode.COOL.value,
+            real_climate_state=HVACMode.COOL.value,  # currently cooling
             real_climate_temp=22,
             inside_temp=mid,
         )
@@ -757,14 +977,12 @@ class TestSyncedSetpoints:
         entity._hvac_mode = HVACMode.AUTO
         entity._preset_mode = PRESET_HOME
         entity._current_temperature = mid
-        # No prior commitment → initial pick will run; never sends OFF.
+        entity._auto_mode = HVACMode.COOL  # already committed to COOL
         await entity._async_sync_real_climate()
-        for call in hass.services.async_call.call_args_list:
-            args = call[0]
-            if args[1] == "set_hvac_mode":
-                assert args[2]["hvac_mode"] != HVACMode.OFF.value
-            elif args[1] == "set_temperature":
-                assert args[2]["hvac_mode"] != HVACMode.OFF.value
+        hass.services.async_call.assert_called_once()
+        call_args = hass.services.async_call.call_args
+        assert call_args[0][1] == "set_hvac_mode"
+        assert call_args[0][2]["hvac_mode"] == HVACMode.OFF.value
 
     @pytest.mark.asyncio
     async def test_sync_off_when_user_commanded_off(self):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -208,32 +208,34 @@ class TestDesiredRealMode:
         assert entity._desired_real_mode() == HVACMode.COOL
         assert entity._auto_mode == HVACMode.COOL
 
-    def test_auto_returns_off_when_inside_band(self):
-        """v3 contract — supersedes v2.0.0's "never returns OFF" rule.
-
-        Inside the comfort band (current ∈ [low, high]), AUTO returns OFF
-        regardless of committed direction. The Midea inverter cannot truly
-        idle inside an active mode; commanding OFF is the only way to stop
-        the compressor when no work is needed.
-
-        Outside the band, the committed direction is honoured: above high
-        with COOL committed → COOL; below low with HEAT committed → HEAT.
-        Wrong-side excursions (committed mode opposite to the demand)
-        return OFF until the FLIP_DWELL/FLIP_MARGIN logic flips the
-        committed direction.
+    def test_auto_cool_returns_off_when_inside_band(self):
+        """v3 contract — narrow surgical change: only AUTO + COOL committed
+        + in-band returns OFF.  Everywhere else AUTO behaves exactly as
+        v2.0.0 (HEAT runs continuously and modulates; COOL outside band
+        does work; wrong-side cases pass committed direction through and
+        let FLIP_DWELL flip the direction).
         """
         low, high = DEFAULT_HOME_MIN, DEFAULT_HOME_MAX
-        # Inside the band: always OFF, regardless of committed direction
-        for inside in [low, low + 0.5, (low + high) / 2, high - 0.5, high]:
-            for prior in (HVACMode.HEAT, HVACMode.COOL):
-                entity = self._entity(inside=inside)
-                entity._auto_mode = prior
-                assert entity._desired_real_mode() == HVACMode.OFF, (
-                    f"current={inside} in [{low},{high}], committed={prior}: "
-                    f"expected OFF, got {entity._desired_real_mode()}"
-                )
 
-        # Outside the band, the committed direction matters
+        # Committed COOL + in band → OFF (the only deviation from v2.0.0)
+        for inside in [low, low + 0.5, (low + high) / 2, high - 0.5, high]:
+            entity = self._entity(inside=inside)
+            entity._auto_mode = HVACMode.COOL
+            assert entity._desired_real_mode() == HVACMode.OFF, (
+                f"COOL committed, current={inside} in [{low},{high}]: "
+                f"expected OFF, got {entity._desired_real_mode()}"
+            )
+
+        # Committed HEAT + in band → HEAT (v2.0.0 unchanged; unit modulates)
+        for inside in [low, low + 0.5, (low + high) / 2, high - 0.5, high]:
+            entity = self._entity(inside=inside)
+            entity._auto_mode = HVACMode.HEAT
+            assert entity._desired_real_mode() == HVACMode.HEAT, (
+                f"HEAT committed, current={inside} in [{low},{high}]: "
+                f"expected HEAT, got {entity._desired_real_mode()}"
+            )
+
+        # Outside the band, both directions do work (v2.0.0 unchanged)
         cool_committed_above = self._entity(inside=high + 1)
         cool_committed_above._auto_mode = HVACMode.COOL
         assert cool_committed_above._desired_real_mode() == HVACMode.COOL
@@ -242,25 +244,26 @@ class TestDesiredRealMode:
         heat_committed_below._auto_mode = HVACMode.HEAT
         assert heat_committed_below._desired_real_mode() == HVACMode.HEAT
 
-        # Wrong-side excursions: OFF (don't fight; flip dwell ticks)
+        # Wrong-side excursions pass committed direction through (v2.0.0).
+        # The FLIP_DWELL timer flips _auto_mode after sustained excursion.
         cool_committed_below = self._entity(inside=low - 1)
         cool_committed_below._auto_mode = HVACMode.COOL
-        assert cool_committed_below._desired_real_mode() == HVACMode.OFF
+        assert cool_committed_below._desired_real_mode() == HVACMode.COOL
 
         heat_committed_above = self._entity(inside=high + 1)
         heat_committed_above._auto_mode = HVACMode.HEAT
-        assert heat_committed_above._desired_real_mode() == HVACMode.OFF
+        assert heat_committed_above._desired_real_mode() == HVACMode.HEAT
 
 
-class TestAutoOffInBand:
-    """OFF as a peer state with HEAT/COOL in AUTO mode.
+class TestAutoCoolOffInBand:
+    """Deliberate-OFF in AUTO is **COOL-only**: the wrapper provides the
+    idle the Midea unit fails to provide in COOL mode.
 
-    Replaces the v2.0.0 "never command OFF in AUTO" contract. On Midea
-    inverter heat pumps the wrapper has to provide the idle state itself,
-    because the unit's COOL/HEAT modes don't truly idle the compressor —
-    they hold at a minimum-frequency floor. Diagnosed empirically on
-    2026-04-26 by reproducing the same over-cooling under both XYE and
-    the factory wired thermostat.
+    Diagnosed empirically 2026-04-25/26: COOL holds a min-frequency floor
+    and pushes 12-14 °C supply air into rooms already in band.  HEAT does
+    *not* have this defect (the unit modulates the compressor down to true
+    idle), so the v2.0.0 "never OFF in AUTO" contract is preserved for
+    HEAT and only narrowed for COOL.
     """
 
     def _entity(self, inside, low=21.0, high=23.0, committed=HVACMode.COOL):
@@ -279,72 +282,104 @@ class TestAutoOffInBand:
         entity._auto_mode = committed
         return entity
 
-    def test_overnight_in_band_traversal_stays_off(self):
+    def test_overnight_cool_in_band_traversal_stays_off(self):
         """Reproduces the 2026-04-25 overnight observation.
 
-        The room stayed in [21, 23] for the entire night (10 h, 1812
-        whole_home_temperature samples, every value 21.2 ≤ t ≤ 22.8).
-        v2.0.0 ran heat→cool→heat→cool cycles all night anyway because
-        of the 'never OFF' rule and the inverter min-frequency floor.
-
-        New behaviour: OFF the entire time, regardless of which direction
-        AUTO has committed to. Compressor stops, room drifts naturally
-        within the band, no useless cooling-then-heating cycles.
+        With COOL committed, the room sat in [21, 23] for the entire
+        night (10 h, 1812 whole_home_temperature samples).  v2.0.0 kept
+        the compressor at min-freq floor and pushed cold air into rooms
+        already in band.  v3 (COOL-only): OFF the entire time.
         """
-        # Sample of actual overnight currents from the diagnostic session
         overnight_currents = [
             21.5, 21.7, 22.0, 22.6, 22.7, 22.5,
             21.4, 21.5, 21.3, 22.6, 22.5, 21.4, 21.3,
             22.6, 22.5, 21.4, 22.5, 21.5, 21.7,
         ]
-        for committed in (HVACMode.HEAT, HVACMode.COOL):
-            for current in overnight_currents:
-                entity = self._entity(
-                    inside=current, low=21.0, high=23.0, committed=committed,
-                )
-                assert entity._desired_real_mode() == HVACMode.OFF, (
-                    f"OVERNIGHT-BUG REGRESSION: current={current} "
-                    f"(in [21, 23]), committed={committed} should be OFF "
-                    f"but got {entity._desired_real_mode()}. The Midea "
-                    f"inverter min-frequency floor wastes energy if AUTO "
-                    f"doesn't OFF in-band."
-                )
+        for current in overnight_currents:
+            entity = self._entity(
+                inside=current, low=21.0, high=23.0, committed=HVACMode.COOL,
+            )
+            assert entity._desired_real_mode() == HVACMode.OFF, (
+                f"COOL OVERNIGHT-BUG REGRESSION: current={current} "
+                f"(in [21, 23]) should be OFF, got "
+                f"{entity._desired_real_mode()}.  The Midea COOL min-"
+                f"frequency floor wastes energy in band."
+            )
 
-    def test_in_band_yields_off_for_both_committed_directions(self):
-        """Tighter point-tests covering the band edges and midpoint."""
+    def test_cool_in_band_yields_off(self):
+        """Point-tests across the band edges and midpoint, COOL committed."""
         for inside in (21.0, 21.5, 22.0, 22.5, 23.0):
-            for committed in (HVACMode.HEAT, HVACMode.COOL):
-                entity = self._entity(inside=inside, committed=committed)
-                assert entity._desired_real_mode() == HVACMode.OFF
+            entity = self._entity(inside=inside, committed=HVACMode.COOL)
+            assert entity._desired_real_mode() == HVACMode.OFF
 
-    def test_above_high_with_cool_committed_runs_cool(self):
-        """Outside band on the right side: do work."""
+    def test_cool_above_high_runs_cool(self):
+        """COOL committed, above band → do work (v2.0.0 unchanged)."""
         entity = self._entity(inside=23.5, committed=HVACMode.COOL)
         assert entity._desired_real_mode() == HVACMode.COOL
 
-    def test_below_low_with_heat_committed_runs_heat(self):
-        entity = self._entity(inside=20.5, committed=HVACMode.HEAT)
+    def test_cool_below_low_runs_cool_v2_compat(self):
+        """COOL committed, below band → COOL passes through (v2.0.0).
+
+        We deliberately do NOT short-circuit to OFF in the wrong-side
+        case.  The user's instruction was: OFF only when tending to cool
+        inside the band.  Wrong-side COOL is rare and the FLIP_DWELL
+        timer flips committed direction to HEAT after 30 min.
+        """
+        entity = self._entity(inside=20.5, committed=HVACMode.COOL)
+        assert entity._desired_real_mode() == HVACMode.COOL
+
+
+class TestAutoHeatNeverOff:
+    """HEAT in AUTO retains v2.0.0's "never command OFF" contract.
+
+    The Midea unit modulates HEAT down to a true compressor idle when
+    the room is at setpoint, so commanding OFF (and absorbing the
+    compressor start-up cost on the next call for heat) costs more than
+    just letting it sit.
+    """
+
+    def _entity(self, inside, low=21.0, high=23.0):
+        hass = _make_hass_mock(inside_temp=inside)
+        config = {
+            CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
+            CONF_INSIDE_SENSOR: INSIDE_SENSOR_ID,
+        }
+        entity = _make_entity(hass, config)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_HOME
+        entity._current_temperature = inside
+        entity._preset_ranges[PRESET_HOME] = (low, high)
+        entity._auto_mode = HVACMode.HEAT
+        return entity
+
+    def test_heat_in_band_stays_heat(self):
+        """HEAT committed + in band → HEAT (let unit idle internally)."""
+        for inside in (21.0, 21.5, 22.0, 22.5, 23.0):
+            entity = self._entity(inside=inside)
+            assert entity._desired_real_mode() == HVACMode.HEAT
+
+    def test_heat_below_low_stays_heat(self):
+        """HEAT committed + cold room → HEAT (real demand)."""
+        entity = self._entity(inside=20.5)
         assert entity._desired_real_mode() == HVACMode.HEAT
 
-    def test_above_high_with_heat_committed_returns_off(self):
-        """Wrong-side excursion: OFF until FLIP_DWELL elapses."""
-        entity = self._entity(inside=23.5, committed=HVACMode.HEAT)
-        assert entity._desired_real_mode() == HVACMode.OFF
-
-    def test_below_low_with_cool_committed_returns_off(self):
-        entity = self._entity(inside=20.5, committed=HVACMode.COOL)
-        assert entity._desired_real_mode() == HVACMode.OFF
+    def test_heat_above_high_stays_heat_v2_compat(self):
+        """HEAT committed + warm room → HEAT (wrong-side; FLIP_DWELL
+        eventually commits direction to COOL).  Pass-through matches
+        v2.0.0; no early OFF short-circuit."""
+        entity = self._entity(inside=23.5)
+        assert entity._desired_real_mode() == HVACMode.HEAT
 
 
 class TestHvacActionInAutoOff:
-    """hvac_action exposes IDLE in deliberate-OFF (AUTO + in-band).
+    """hvac_action surfaces IDLE in deliberate-OFF (AUTO + COOL + in-band).
 
     The real Midea unit, when commanded OFF, reports hvac_action='off'.
-    The wrapper hides that and surfaces IDLE instead so the user sees
+    The wrapper hides that and shows IDLE instead so the user sees
     "AUTO is resting between calls for work" rather than the alarming
     "thermostat is OFF" — which usually signals a manual user override.
-    Outside the deliberate-OFF state, hvac_action mirrors the real
-    device's reported action verbatim.
+    Outside the deliberate-OFF state (HEAT in AUTO, COOL outside band,
+    user OFF), hvac_action mirrors the real device's reported action.
     """
 
     def _entity(self, inside, low=21.0, high=23.0, committed=HVACMode.COOL):
@@ -362,14 +397,28 @@ class TestHvacActionInAutoOff:
         return entity
 
     @pytest.mark.asyncio
-    async def test_idle_when_auto_in_band(self):
-        """AUTO + in-band → wrapper sends OFF → hvac_action == IDLE."""
-        entity = self._entity(inside=22.0)  # mid of [21, 23]
+    async def test_idle_when_auto_cool_in_band(self):
+        """AUTO + COOL + in-band → wrapper sends OFF → hvac_action == IDLE."""
+        entity = self._entity(inside=22.0, committed=HVACMode.COOL)
         # Real device will be commanded OFF and report 'off' back to us.
         entity._hvac_action = HVACAction.OFF
         await entity._async_sync_real_climate()
         assert entity._unit_command == HVACMode.OFF
         assert entity.hvac_action == HVACAction.IDLE
+
+    @pytest.mark.asyncio
+    async def test_no_idle_when_auto_heat_in_band(self):
+        """AUTO + HEAT + in-band → unit runs HEAT (modulating) → mirror.
+
+        IDLE is COOL-only.  HEAT in AUTO never commands the real device
+        OFF, so the unit's mirrored action (HEATING or its own internal
+        idle) is what the user should see.
+        """
+        entity = self._entity(inside=22.0, committed=HVACMode.HEAT)
+        entity._hvac_action = HVACAction.HEATING
+        await entity._async_sync_real_climate()
+        assert entity._unit_command == HVACMode.HEAT
+        assert entity.hvac_action == HVACAction.HEATING
 
     @pytest.mark.asyncio
     async def test_mirrors_cooling_when_above_high(self):
@@ -959,13 +1008,12 @@ class TestSyncedSetpoints:
         hass.services.async_call.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_sync_in_auto_sends_off_when_in_band(self):
-        """v3 contract — supersedes v2.0.0's "never OFF in AUTO" rule.
+    async def test_sync_cool_sends_off_in_band(self):
+        """v3 contract — narrow surgical change vs. v2.0.0.
 
-        Inside the comfort band the wrapper commands the real device OFF
-        so the Midea inverter actually idles instead of holding its
-        minimum-frequency floor and pumping conditioned air the room
-        doesn't need.
+        AUTO + COOL committed + in band: the wrapper commands the real
+        device OFF so the Midea unit actually idles instead of holding
+        its COOL minimum-frequency floor.
         """
         mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
         hass = _make_hass_mock(
@@ -983,6 +1031,33 @@ class TestSyncedSetpoints:
         call_args = hass.services.async_call.call_args
         assert call_args[0][1] == "set_hvac_mode"
         assert call_args[0][2]["hvac_mode"] == HVACMode.OFF.value
+
+    @pytest.mark.asyncio
+    async def test_sync_heat_never_sends_off_in_band(self):
+        """v2.0.0 contract preserved for HEAT: never OFF in AUTO+HEAT.
+
+        The Midea unit modulates HEAT down to a true compressor idle when
+        in band; commanding OFF would trade that for a start-up cost on
+        the next call for heat.
+        """
+        mid = (DEFAULT_HOME_MIN + DEFAULT_HOME_MAX) / 2
+        hass = _make_hass_mock(
+            real_climate_state=HVACMode.HEAT.value,
+            real_climate_temp=22,
+            inside_temp=mid,
+        )
+        entity = _make_entity(hass)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_HOME
+        entity._current_temperature = mid
+        entity._auto_mode = HVACMode.HEAT
+        await entity._async_sync_real_climate()
+        for call in hass.services.async_call.call_args_list:
+            args = call[0]
+            sent_mode = args[2].get("hvac_mode")
+            assert sent_mode != HVACMode.OFF.value, (
+                f"HEAT in AUTO must never send OFF; got {args}"
+            )
 
     @pytest.mark.asyncio
     async def test_sync_off_when_user_commanded_off(self):


### PR DESCRIPTION
## Summary

**Asymmetric, narrow-scope correction to v2.0.0''s "never command OFF in AUTO" rule.**  Only AUTO + COOL committed + in-band changes behavior; HEAT in AUTO is unchanged from v2.0.0.

### What changed and why

v2.0.0 contracted "never OFF in AUTO" on the assumption that the wrapped device would idle its compressor at min modulation in any active mode.  Empirical results 2026-04-25 / 2026-04-26:

| Mode | Min-frequency floor in band? | Energy verdict |
|---|---|---|
| **COOL** | Yes — min-freq compressor pumps 12-14 °C supply air into rooms already in band | wastes energy |
| **HEAT** | **No — unit idles compressor properly** | v2.0.0 was right; do nothing |

### Why the asymmetry exists (refined theory)

Initial guess was that COOL''s min-freq floor served the unit''s internal dehumidification logic.  That fits superficially — the unit has a separate selectable Dry mode, **available only in COOL**.  But Dry mode is *off* during the diagnostic and COOL still floors, so dehumidification can''t be the active driver.

Better explanation: **refrigerant-cycle direction**.

- In **COOL**, the indoor coil is the cold sink.  When the compressor stops, refrigerant migrates to it.  On the next restart that liquid refrigerant can return to the compressor as a slug — bearing wear or protection shutdown.  Holding minimum frequency prevents migration.
- In **HEAT**, the cycle reverses (indoor coil is the hot side).  Refrigerant migrates outdoors when stopped — benign, no slug risk on restart.  Compressor protection logic only needs to forbid full idle in COOL.

The Dry-mode-COOL-only pairing is then explained simply by thermodynamics (dehumidification needs a cold coil to condense moisture, and only COOL gives you that) — not evidence about *how* COOL is controlled.

So v2.0.0''s "never OFF" rule is *correct* for HEAT (start-up cost > min-freq idle cost, no protection penalty) and *wrong* for COOL on this unit (min-freq pumps unwanted cold air).  v3 makes the correction asymmetric to match.

### v3 contract (asymmetric)

| `_auto_mode` | `current` vs `[low, high]` | Unit command |
|---|---|---|
| HEAT | (any) | HEAT — v2.0.0 unchanged |
| COOL | in band | **OFF** — the only deviation |
| COOL | above high | COOL — v2.0.0 |
| COOL | below low | COOL — v2.0.0; FLIP_DWELL flips to HEAT |

`hvac_action` returns `IDLE` (not `OFF`) on the wrapper whenever the wrapper has commanded the real device OFF — distinguishes "AUTO resting" from "user turned it off entirely".

### Risk profile

Damage risk from cycling COOL on/off is **low**:

- We use the manufacturer''s `set_hvac_mode` service.  The unit''s firmware runs its own shutdown sequence (pump-down, valve positioning) and startup sequence (soft-start ramp from low frequency).  We''re not yanking power.
- Modern inverter units have built-in anti-short-cycle protection: if the wrapper commands COOL within ~3-5 min of an OFF, the unit queues the request internally.
- Inverter compressors are far more cycle-tolerant than single-stage; soft-start makes each cycle cheap in wear terms (~30 s of equivalent steady-state runtime per start).
- The OFF command we send is identical to a user pressing OFF on the wired thermostat.

Cumulative wear is real but minor.  The 2 °C band width should comfortably keep cycles under 2/hour in practice.

### Known design wart: wrong-side COOL excursion

Per user direction at PR time (*"OFF only when tending to cool inside the band"*), v3 deliberately keeps v2.0.0 behavior in the wrong-side COOL case: **COOL committed + current < low → COOL** (and `FLIP_DWELL` flips to HEAT after 30 min).

Surfaces on cool spring/fall nights after a warm day: AUTO is still committed COOL from the afternoon, the room drifts below low overnight, and the wrapper sends COOL into a cold room for up to 30 minutes before the dwell-flip.  Empirically small (the unit modulates and the gradient is small), but visible in logs.

Surgical fix sketched in `CLAUDE.md` Future Work #3 if live data shows it matters.

### Tests (77 pass)

- **`TestAutoCoolOffInBand`** (4 tests): in-band → OFF, above-high → COOL, below-low → COOL (v2.0.0 compat), plus the 2026-04-25 overnight-traversal regression.
- **`TestAutoHeatNeverOff`** (3 tests): HEAT committed always returns HEAT, including in-band, below-low, above-high (wrong-side, FLIP_DWELL-handled).
- **`TestHvacActionInAutoOff`** (6 tests): IDLE in COOL+in-band; mirror in HEAT+in-band; mirror in HEAT/COOL out-of-band; OFF when user-OFF; pass-through when no command yet.
- **`TestSyncedSetpoints`**: `test_sync_cool_sends_off_in_band` (new) + `test_sync_heat_never_sends_off_in_band` (new, pins v2.0.0 contract).
- **Rebased**: `TestStickyAutoMode` and `TestDesiredRealMode` initial-pick tests assert `_auto_mode` (committed direction) since the unit-command return is now band-dependent.

### Test plan

- [x] `pytest tests/test_climate.py` — 77 green
- [ ] Deploy to live HA at duvall.calvonet.com
- [ ] **Daytime confirmation** (sunny PNW afternoon, ~16-17 °C outside, indoor in [21, 23]):
  - [ ] AUTO+COOL with current in band → `climate.thermostat` reads `off`, wrapper `hvac_action` reads `idle`
  - [ ] AUTO+HEAT with current in band → `climate.thermostat` runs HEAT (modulating, no OFF command)
  - [ ] AUTO+COOL with current > high → wrapper resumes COOL
- [ ] **Overnight observation** (clear PNW night, 6-9 °C outside per `weather.duvall`):
  - [ ] Watch for sustained `cool` between 1-5 AM with current < 21.  If seen: wrong-side-COOL wart fired, queue Future Work #3.
  - [ ] Otherwise: clean OFF the entire night = expected behavior.
- [ ] Watch for COOL short-cycling at the band edges over the first week; if > 6 starts/hour sustained, add `OFF_HOLD_UP` minimum-OFF timer (CLAUDE.md Future Work #2).
- [ ] Watch HA logs for any Midea protection-trip codes after deployment.

### Breaking change

Downstream automations that assumed AUTO would never produce `hvac_mode=off` on the wrapped entity must be updated.  In practice this only fires now when COOL is committed AND current is in `[low, high]`.