### PR TITLE
fix: add in-band COOL hysteresis (high → mid pull)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,32 +387,46 @@ Watch in live deployment:
    straight to high, soft-start isn't engaging; revisit.
 3. **Protection trip codes** in HA logs after the first weeks.
 
-### Implemented behavior (v3.0.0 + v3.0.x hysteresis fix)
+### Implemented behavior (v3.0.0 + v3.0.x hysteresis fixes)
 
 Sticky AUTO commitment from v2.0.0 is unchanged.  The unit command
 derived from the committed direction:
 
-| `_auto_mode` | `current` vs `[low, high]` | Last command | Unit command |
-|--------------|---------------------------|--------------|--------------|
-| HEAT         | (any)                     | (any)        | HEAT (v2.0.0 unchanged) |
-| COOL         | above high                | (any)        | COOL (v2.0.0) |
-| COOL         | below low                 | (any)        | COOL (v2.0.0; FLIP_DWELL flips to HEAT) |
-| COOL         | in band, > mid            | COOL         | COOL (keep cooling to mid) |
-| COOL         | in band, ≤ mid            | COOL         | OFF |
-| COOL         | in band                   | OFF / None   | OFF |
+| `_auto_mode` | `current` | Last command | Unit command |
+|--------------|-----------|--------------|--------------|
+| HEAT         | (any)                          | (any)        | HEAT (v2.0.0 unchanged) |
+| COOL         | `> high`                       | (any)        | COOL (v2.0.0) |
+| COOL         | `< low`                        | (any)        | COOL (v2.0.0; FLIP_DWELL → HEAT) |
+| COOL         | in band, `> mid`               | COOL         | COOL (keep cooling to mid) |
+| COOL         | in band, `≤ mid`               | COOL         | OFF |
+| COOL         | in band, `> mid + RESTART_OFF` | OFF / None   | COOL (lead the high edge) |
+| COOL         | in band, `≤ mid + RESTART_OFF` | OFF / None   | OFF |
 
-**In-band COOL hysteresis** added in v3.0.x.  v3.0.0 used a flat
-threshold at the band edge; live deployment 2026-04-26 caught the
-short-cycling — temp hit 23.0, COOL ran for 2 minutes, OFF as soon
-as it dropped back into band.  No useful pull, just compressor
-start + immediate stop.  The hysteresis (start above high, stop at
-midpoint) ensures each compressor start does ~½-band of useful
-cooling before stopping, amortising start-up cost.
+**In-band COOL hysteresis with offset restart**.  Two sequential
+fixes after the v3.0.0 deploy on 2026-04-26:
+
+1. **Stop at midpoint, not band edge.**  v3.0.0 returned OFF the
+   moment current re-entered `[low, high]` from above.  Live result:
+   2-min COOL pulses with no useful pull.  Fix: keep cooling until
+   `current ≤ mid` so each start does ~½-band of cooling.
+
+2. **Restart leads the high edge.**  Restarting at the high edge
+   (e.g. `> 23` for the [21, 23] home preset) is too late — by the
+   time the wrapper sees current cross 23, the unit's ramp + air-
+   circulation lag has already let the room overshoot.  Fix: restart
+   at `mid + COOL_RESTART_OFFSET` (default 0.75 °C above mid =
+   22.75 for home preset).  COOL flow reaches the sensor before
+   current would otherwise have hit high.
 
 State is keyed on `_unit_command` (the wrapper's last sent command):
-- Was OFF → stay OFF until current rises above high
-- Was COOL → stay COOL until current drops to midpoint
+- Was OFF → stay OFF until current rises above `mid + RESTART_OFFSET`
+- Was COOL → stay COOL until current drops to `mid`
 - First sync (`None`) treated as OFF state (don't start uninvited)
+
+The 0.25 °C between restart threshold and high edge is intentional
+headroom for the unit's response lag, *not* unused band.  Tightens
+control vs. starting at the edge, at the cost of more frequent (but
+still meaningful) compressor pulls.
 
 `hvac_action` returns `IDLE` (not `OFF`) on the wrapper whenever
 the unit_command is OFF — distinguishes "AUTO resting" from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,6 +428,17 @@ headroom for the unit's response lag, *not* unused band.  Tightens
 control vs. starting at the edge, at the cost of more frequent (but
 still meaningful) compressor pulls.
 
+**Requires a sub-degree (decimal) inside-temperature sensor.**  The
+hysteresis depends on resolving values like 22.7 vs. 22.8 to land
+inside the 0.25 °C lead-headroom band between the restart threshold
+and the high edge.  A whole-degree sensor would jump 22 → 23 and
+skip the threshold entirely, defeating the lead and reverting to
+start-at-high (the original short-cycling bug).  This deployment
+uses Aeotec Multisensor 7 sensors (0.1 °C resolution) — fine.  For
+coarser sensors, raise `COOL_RESTART_OFFSET` to at least
+`(sensor_resolution + 0.5 °C)` so the lead headroom is wider than
+one sensor step.
+
 `hvac_action` returns `IDLE` (not `OFF`) on the wrapper whenever
 the unit_command is OFF — distinguishes "AUTO resting" from
 "user turned it off entirely".  Implemented via a `_unit_command`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,17 +387,32 @@ Watch in live deployment:
    straight to high, soft-start isn't engaging; revisit.
 3. **Protection trip codes** in HA logs after the first weeks.
 
-### Implemented behavior (v3.0.0)
+### Implemented behavior (v3.0.0 + v3.0.x hysteresis fix)
 
-Sticky AUTO commitment from v2.0.0 is unchanged.  The only change
-is in the unit command derived from the committed direction:
+Sticky AUTO commitment from v2.0.0 is unchanged.  The unit command
+derived from the committed direction:
 
-| `_auto_mode` | `current` vs `[low, high]` | Unit command |
-|--------------|---------------------------|--------------|
-| HEAT         | (any)                     | HEAT (v2.0.0 unchanged) |
-| COOL         | in band                   | **OFF** |
-| COOL         | above high                | COOL (v2.0.0) |
-| COOL         | below low                 | COOL (v2.0.0; FLIP_DWELL flips to HEAT) |
+| `_auto_mode` | `current` vs `[low, high]` | Last command | Unit command |
+|--------------|---------------------------|--------------|--------------|
+| HEAT         | (any)                     | (any)        | HEAT (v2.0.0 unchanged) |
+| COOL         | above high                | (any)        | COOL (v2.0.0) |
+| COOL         | below low                 | (any)        | COOL (v2.0.0; FLIP_DWELL flips to HEAT) |
+| COOL         | in band, > mid            | COOL         | COOL (keep cooling to mid) |
+| COOL         | in band, ≤ mid            | COOL         | OFF |
+| COOL         | in band                   | OFF / None   | OFF |
+
+**In-band COOL hysteresis** added in v3.0.x.  v3.0.0 used a flat
+threshold at the band edge; live deployment 2026-04-26 caught the
+short-cycling — temp hit 23.0, COOL ran for 2 minutes, OFF as soon
+as it dropped back into band.  No useful pull, just compressor
+start + immediate stop.  The hysteresis (start above high, stop at
+midpoint) ensures each compressor start does ~½-band of useful
+cooling before stopping, amortising start-up cost.
+
+State is keyed on `_unit_command` (the wrapper's last sent command):
+- Was OFF → stay OFF until current rises above high
+- Was COOL → stay COOL until current drops to midpoint
+- First sync (`None`) treated as OFF state (don't start uninvited)
 
 `hvac_action` returns `IDLE` (not `OFF`) on the wrapper whenever
 the unit_command is OFF — distinguishes "AUTO resting" from

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -497,19 +497,28 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         idle in HEAT when the room is at setpoint, so continuous HEAT at
         min modulation costs less than OFF/ON cycling.
 
-        **Committed COOL** — narrow, surgical change vs. v2.0.0.  The
-        *only* deviation from v2.0.0 is in-band:
-        - `current ∈ [low, high]`  →  **OFF** (no work needed)
-        - `current > high`         →  COOL  (v2.0.0)
-        - `current < low`          →  COOL  (v2.0.0; FLIP_DWELL flips
-                                     committed direction to HEAT)
+        **Committed COOL** — narrow, surgical change vs. v2.0.0, with
+        hysteresis around the band edges:
+        - currently OFF & `current > high`  →  COOL  (start cooling)
+        - currently COOL & `current > mid`  →  COOL  (keep cooling)
+        - currently COOL & `current ≤ mid`  →  OFF   (stop at midpoint)
+        - currently OFF & `current ≤ high`  →  OFF
+        - `current < low`                   →  COOL  (v2.0.0; FLIP_DWELL
+                                              flips committed dir to HEAT)
 
-        Why only here: on this Midea unit the COOL mode holds a minimum-
-        frequency floor and keeps pushing 12-14 °C supply air into rooms
-        that are already in band — diagnosed empirically 2026-04-25.  HEAT
-        does not have this defect, and COOL outside the band still has
-        real demand to chase.  The wrong-side COOL case (below low) is
-        rare and the existing 30-min dwell flip handles it.
+        The hysteresis (start above high, stop at midpoint) is what
+        prevents short-cycling: a flat threshold at the band edge would
+        OFF after a fraction of a degree of cooling.  Going down to mid
+        gives each compressor start ~½-band of useful cooling before
+        stopping, amortising start-up cost.
+
+        Why only COOL needs this: on this Midea unit the COOL mode holds
+        a minimum-frequency floor and keeps pushing 12-14 °C supply air
+        into rooms already in band — diagnosed empirically 2026-04-25.
+        HEAT does not have this defect (refrigerant migrates outdoors
+        when stopped, no slug-on-restart risk), and COOL outside the band
+        still has real demand to chase.  The wrong-side COOL case (below
+        low) is rare and the existing 30-min dwell flip handles it.
         """
         if self._hvac_mode == HVACMode.OFF:
             return HVACMode.OFF
@@ -557,15 +566,24 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             self._pending_flip_since = None
 
         # Unit command — asymmetric between committed directions.
-        # COOL: in-band → OFF; outside band → COOL (matches v2.0.0
-        # everywhere except the in-band case where the Midea min-frequency
-        # floor wastes energy).
         # HEAT: always HEAT (v2.0.0 contract unchanged; the unit modulates
         # to true idle in HEAT when no demand).
+        # COOL: hysteresis inside the band, v2.0.0 elsewhere.
+        #   above high           → COOL (real demand; v2.0.0)
+        #   below low            → COOL (wrong-side; v2.0.0; FLIP_DWELL flips)
+        #   in band, was COOL    → COOL until current ≤ mid, then OFF
+        #   in band, was OFF     → OFF until current > high
+        # The hysteresis prevents short-cycling at the high edge: a flat
+        # threshold would OFF after a fraction of a degree of cooling.
+        # Stopping at the midpoint gives each compressor start ~½-band of
+        # useful pull before stopping, amortising the start-up cost.
         if self._auto_mode == HVACMode.COOL:
-            if low <= inside <= high:
-                return HVACMode.OFF
-            return HVACMode.COOL
+            if inside > high or inside < low:
+                return HVACMode.COOL
+            # Inside the band: hysteresis keyed on the previous command.
+            if self._unit_command == HVACMode.COOL and inside > mid:
+                return HVACMode.COOL
+            return HVACMode.OFF
         return HVACMode.HEAT
 
     # ------------------------------------------------------------------

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_REAL_CLIMATE,
     CONF_SLEEP_MAX,
     CONF_SLEEP_MIN,
+    COOL_RESTART_OFFSET,
     DEFAULT_AWAY_MAX,
     DEFAULT_AWAY_MIN,
     DEFAULT_HOME_MAX,
@@ -498,19 +499,22 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         min modulation costs less than OFF/ON cycling.
 
         **Committed COOL** — narrow, surgical change vs. v2.0.0, with
-        hysteresis around the band edges:
-        - currently OFF & `current > high`  →  COOL  (start cooling)
-        - currently COOL & `current > mid`  →  COOL  (keep cooling)
-        - currently COOL & `current ≤ mid`  →  OFF   (stop at midpoint)
-        - currently OFF & `current ≤ high`  →  OFF
-        - `current < low`                   →  COOL  (v2.0.0; FLIP_DWELL
-                                              flips committed dir to HEAT)
+        hysteresis above the band midpoint:
+        - currently OFF & `current > mid + COOL_RESTART_OFFSET`  →  COOL  (start)
+        - currently COOL & `current > mid`                       →  COOL  (keep cooling)
+        - currently COOL & `current ≤ mid`                       →  OFF   (stop at mid)
+        - currently OFF & `current ≤ mid + COOL_RESTART_OFFSET`  →  OFF
+        - `current > high`                                       →  COOL  (above-band, always)
+        - `current < low`                                        →  COOL  (v2.0.0 wrong-side;
+                                                                   FLIP_DWELL flips to HEAT)
 
-        The hysteresis (start above high, stop at midpoint) is what
-        prevents short-cycling: a flat threshold at the band edge would
-        OFF after a fraction of a degree of cooling.  Going down to mid
-        gives each compressor start ~½-band of useful cooling before
-        stopping, amortising start-up cost.
+        The hysteresis (start at `mid + COOL_RESTART_OFFSET`, stop at
+        `mid`) prevents short-cycling at the band edge.  With the default
+        home preset (21-23, mid=22, offset=0.75) cooling kicks in at
+        22.75 and pulls down to 22 — leaving the upper 0.25 °C of the
+        comfort band as headroom rather than the active operating zone.
+        Tightens control vs. waiting for the high edge, at the cost of
+        more frequent but still-meaningful compressor pulls.
 
         Why only COOL needs this: on this Midea unit the COOL mode holds
         a minimum-frequency floor and keeps pushing 12-14 °C supply air
@@ -568,20 +572,25 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # Unit command — asymmetric between committed directions.
         # HEAT: always HEAT (v2.0.0 contract unchanged; the unit modulates
         # to true idle in HEAT when no demand).
-        # COOL: hysteresis inside the band, v2.0.0 elsewhere.
-        #   above high           → COOL (real demand; v2.0.0)
-        #   below low            → COOL (wrong-side; v2.0.0; FLIP_DWELL flips)
-        #   in band, was COOL    → COOL until current ≤ mid, then OFF
-        #   in band, was OFF     → OFF until current > high
-        # The hysteresis prevents short-cycling at the high edge: a flat
-        # threshold would OFF after a fraction of a degree of cooling.
-        # Stopping at the midpoint gives each compressor start ~½-band of
-        # useful pull before stopping, amortising the start-up cost.
+        # COOL: hysteresis above midpoint inside the band, v2.0.0 elsewhere.
+        #   above high                              → COOL (above-band; v2.0.0)
+        #   below low                               → COOL (wrong-side; v2.0.0)
+        #   was COOL, current > mid                 → COOL (keep cooling to mid)
+        #   was COOL, current ≤ mid                 → OFF (full pull achieved)
+        #   was OFF, current > mid + RESTART_OFFSET → COOL (start, lead high edge)
+        #   was OFF, current ≤ mid + RESTART_OFFSET → OFF
+        # The restart offset (default 0.75 °C above mid) leads the high
+        # edge so the compressor has time to ramp before current would
+        # otherwise overshoot the band.  Stopping at midpoint gives each
+        # start a meaningful pull, amortising start-up cost.
         if self._auto_mode == HVACMode.COOL:
             if inside > high or inside < low:
                 return HVACMode.COOL
             # Inside the band: hysteresis keyed on the previous command.
-            if self._unit_command == HVACMode.COOL and inside > mid:
+            if self._unit_command == HVACMode.COOL:
+                return HVACMode.COOL if inside > mid else HVACMode.OFF
+            # Was OFF (or first sync) — restart well shy of the high edge.
+            if inside > mid + COOL_RESTART_OFFSET:
                 return HVACMode.COOL
             return HVACMode.OFF
         return HVACMode.HEAT

--- a/custom_components/smart_climate/const.py
+++ b/custom_components/smart_climate/const.py
@@ -52,4 +52,14 @@ FLIP_DWELL = 1800  # 30 min
 # rather than the active operating zone.  Tightens control vs. starting
 # at the high edge, at the cost of more frequent (but still meaningful)
 # compressor pulls.
+#
+# REQUIRES a sub-degree (decimal) inside-temperature sensor.  Whole-degree
+# sensors (e.g., a thermostat that reports 22 → 23 → 22) skip over the
+# 22.75 restart threshold entirely and produce alternating jumps from
+# below-restart (OFF) to above-high (COOL) — the 0.25 °C lead-headroom
+# becomes invisible and the wrapper effectively reverts to start-at-high
+# behaviour with all the short-cycling that motivated this fix.  The
+# Aeotec ZW100 / Multisensor 7 family used in this deployment reports
+# 0.1 °C resolution, which is fine.  If you wire a coarser sensor, raise
+# COOL_RESTART_OFFSET to (sensor_resolution + 0.5 °C) or wider.
 COOL_RESTART_OFFSET = 0.75

--- a/custom_components/smart_climate/const.py
+++ b/custom_components/smart_climate/const.py
@@ -42,3 +42,14 @@ MIN_TEMP_DIFF = 0.5
 # operation.
 FLIP_MARGIN = 0.5
 FLIP_DWELL = 1800  # 30 min
+
+# COOL hysteresis around the band midpoint.  In AUTO + COOL committed:
+#   start cooling when current > mid + COOL_RESTART_OFFSET
+#   stop cooling when current ≤ mid
+# Keeps the room well shy of the high edge of the comfort band — for the
+# default home preset (21-23, mid=22) this means COOL kicks in at 22.75
+# and pulls down to 22, leaving the upper 0.25 °C of the band as headroom
+# rather than the active operating zone.  Tightens control vs. starting
+# at the high edge, at the cost of more frequent (but still meaningful)
+# compressor pulls.
+COOL_RESTART_OFFSET = 0.75

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -20,6 +20,7 @@ from custom_components.smart_climate.const import (
     CONF_REAL_CLIMATE,
     CONF_INSIDE_SENSOR,
     CONF_OUTSIDE_SENSOR,
+    COOL_RESTART_OFFSET,
     DEFAULT_HOME_MIN,
     DEFAULT_HOME_MAX,
     DEFAULT_SLEEP_MIN,
@@ -216,14 +217,17 @@ class TestDesiredRealMode:
         let FLIP_DWELL flip the direction).
         """
         low, high = DEFAULT_HOME_MIN, DEFAULT_HOME_MAX
-
-        # Committed COOL + in band → OFF (the only deviation from v2.0.0)
-        for inside in [low, low + 0.5, (low + high) / 2, high - 0.5, high]:
+        mid = (low + high) / 2
+        # Below the COOL restart threshold (mid + COOL_RESTART_OFFSET): OFF.
+        # Above it but in band: hysteresis would START cooling — see
+        # TestAutoCoolHysteresis for that side.
+        for inside in [low, low + 0.5, mid]:
             entity = self._entity(inside=inside)
             entity._auto_mode = HVACMode.COOL
             assert entity._desired_real_mode() == HVACMode.OFF, (
-                f"COOL committed, current={inside} in [{low},{high}]: "
-                f"expected OFF, got {entity._desired_real_mode()}"
+                f"COOL committed, current={inside} below restart "
+                f"threshold {mid + COOL_RESTART_OFFSET}: expected OFF, "
+                f"got {entity._desired_real_mode()}"
             )
 
         # Committed HEAT + in band → HEAT (v2.0.0 unchanged; unit modulates)
@@ -306,11 +310,21 @@ class TestAutoCoolOffInBand:
                 f"frequency floor wastes energy in band."
             )
 
-    def test_cool_in_band_yields_off(self):
-        """Point-tests across the band edges and midpoint, COOL committed."""
-        for inside in (21.0, 21.5, 22.0, 22.5, 23.0):
+    def test_cool_in_band_below_restart_threshold_yields_off(self):
+        """COOL committed, current ≤ mid + COOL_RESTART_OFFSET, OFF state.
+
+        Hysteresis-aware: in this regime the wrapper holds OFF until the
+        restart threshold (default 0.75 °C above mid) is exceeded.  The
+        upper sliver between threshold and high is the "start cooling"
+        zone (covered by TestAutoCoolHysteresis) and not OFF here.
+        """
+        # Band [21, 23], mid=22, restart threshold=22.75
+        for inside in (21.0, 21.5, 22.0, 22.5, 22.75):
             entity = self._entity(inside=inside, committed=HVACMode.COOL)
-            assert entity._desired_real_mode() == HVACMode.OFF
+            assert entity._desired_real_mode() == HVACMode.OFF, (
+                f"OFF state at {inside} (≤22.75): expected OFF, "
+                f"got {entity._desired_real_mode()}"
+            )
 
     def test_cool_above_high_runs_cool(self):
         """COOL committed, above band → do work (v2.0.0 unchanged)."""
@@ -359,6 +373,30 @@ class TestAutoCoolHysteresis:
         entity._unit_command = last_cmd
         return entity
 
+    def test_restart_leads_high_edge_not_at_it(self):
+        """Live-deployment regression 2026-04-26.
+
+        User report: "by the time it reaches 23 is too late, we will be
+        outside band".  v3.0.1 with restart-at-high (≥23) would let the
+        compressor's ramp + air-circulation lag push the room *over*
+        the high edge before COOL flow reaches the sensor.
+
+        Fix: restart at mid + COOL_RESTART_OFFSET (default 22.75 for
+        the [21, 23] home preset).  By the time the room would have
+        otherwise reached 23, COOL is already active and pulling down.
+        """
+        # 22.5 — well below threshold, OFF state, must stay OFF
+        e = self._entity(inside=22.5, last_cmd=HVACMode.OFF)
+        assert e._desired_real_mode() == HVACMode.OFF
+        # 22.75 — exactly at threshold, OFF state, still OFF
+        e._current_temperature = 22.75
+        assert e._desired_real_mode() == HVACMode.OFF
+        # 22.8 — past threshold, OFF state, START COOL (lead the high edge)
+        e._current_temperature = 22.8
+        assert e._desired_real_mode() == HVACMode.COOL, (
+            "must restart BEFORE high edge, not at/after it"
+        )
+
     def test_keeps_cooling_above_midpoint(self):
         """COOL state, current still above mid → keep cooling.
 
@@ -381,47 +419,70 @@ class TestAutoCoolHysteresis:
                 f"got {entity._desired_real_mode()}"
             )
 
-    def test_off_state_does_not_restart_in_band(self):
-        """OFF state, current still ≤ high → stay OFF (no restart).
+    def test_off_state_does_not_restart_below_offset(self):
+        """OFF state, current ≤ mid + offset → stay OFF.
 
-        This is the other half of the hysteresis: once OFF, the wrapper
-        does not restart COOL until current rises above the high edge.
+        The wrapper holds OFF until current rises *above* mid + offset
+        (default 22.75 for the [21, 23] band).  The 0.25 °C between the
+        restart threshold and the high edge is intentional headroom —
+        if the wrapper waited until the high edge to restart, the unit's
+        ramp + air-circulation lag would let the room overshoot the band.
         """
-        for inside in (21.0, 22.0, 22.9, 23.0):
+        for inside in (21.0, 22.0, 22.5, 22.75):
             entity = self._entity(inside=inside, last_cmd=HVACMode.OFF)
             assert entity._desired_real_mode() == HVACMode.OFF, (
-                f"OFF state at {inside} (≤high=23): expected OFF, "
+                f"OFF state at {inside} (≤22.75): expected OFF, "
                 f"got {entity._desired_real_mode()}"
             )
 
-    def test_off_state_restarts_above_high(self):
-        """OFF state, current > high → start COOL."""
-        for inside in (23.01, 23.5, 24.0):
+    def test_off_state_restarts_above_offset_lead_high(self):
+        """OFF state, current > mid + offset → start COOL.
+
+        Restart fires before the room reaches the high edge so the
+        compressor has time to ramp.  By the time current would have
+        hit high, COOL air is already flowing.
+        """
+        for inside in (22.76, 22.9, 23.0, 23.5, 24.0):
             entity = self._entity(inside=inside, last_cmd=HVACMode.OFF)
-            assert entity._desired_real_mode() == HVACMode.COOL
+            assert entity._desired_real_mode() == HVACMode.COOL, (
+                f"OFF state at {inside} (>22.75): expected COOL, "
+                f"got {entity._desired_real_mode()}"
+            )
 
     def test_first_sync_with_no_prior_command_treats_as_off_state(self):
         """`_unit_command is None` (first sync) behaves like OFF state:
-        in band → stay OFF; above high → COOL."""
-        e_in_band = self._entity(inside=22.5, last_cmd=None)
-        assert e_in_band._desired_real_mode() == HVACMode.OFF
-        e_above = self._entity(inside=24.0, last_cmd=None)
-        assert e_above._desired_real_mode() == HVACMode.COOL
+        ≤ mid+offset → stay OFF; > mid+offset → COOL."""
+        e_below = self._entity(inside=22.5, last_cmd=None)
+        assert e_below._desired_real_mode() == HVACMode.OFF
+        e_above_threshold = self._entity(inside=22.8, last_cmd=None)
+        assert e_above_threshold._desired_real_mode() == HVACMode.COOL
 
-    def test_full_pull_cycle_minimum_two_starts_per_full_cycle(self):
-        """End-to-end: simulate temp 24 → 22 → 24 → 22 with the wrapper
-        tracking _unit_command.  Verify exactly one COOL start per
-        full cycle (not two from short-cycling at 23)."""
-        # Cycle 1: 24 → start COOL
-        e = self._entity(inside=24.0, last_cmd=HVACMode.OFF)
+    def test_full_pull_cycle_one_start_per_cycle(self):
+        """End-to-end: simulate temp drift 22 → 22.75 → 22.8 → 22 → 22.8
+        with the wrapper tracking _unit_command.  Verify exactly one
+        COOL start per full cycle (not multiple flickers near the
+        restart threshold)."""
+        # Start at midpoint, OFF state
+        e = self._entity(inside=22.0, last_cmd=HVACMode.OFF)
+        assert e._desired_real_mode() == HVACMode.OFF
+
+        # Drift up through OFF zone — must stay OFF
+        for t in (22.25, 22.5, 22.75):
+            e._current_temperature = t
+            assert e._desired_real_mode() == HVACMode.OFF, (
+                f"OFF state at {t} (≤22.75): expected OFF"
+            )
+
+        # Cross the restart threshold → start COOL
+        e._current_temperature = 22.8
         assert e._desired_real_mode() == HVACMode.COOL
-        e._unit_command = HVACMode.COOL  # simulate sync committed COOL
+        e._unit_command = HVACMode.COOL
 
-        # Drift down through band — must stay COOL until mid
-        for t in (23.5, 23.0, 22.5, 22.1):
+        # Drift down through the band — keep COOL all the way to mid
+        for t in (22.7, 22.5, 22.25, 22.1):
             e._current_temperature = t
             assert e._desired_real_mode() == HVACMode.COOL, (
-                f"COOL state at {t} should stay COOL"
+                f"COOL state at {t} (>mid=22) should stay COOL"
             )
 
         # Hit mid → OFF
@@ -429,15 +490,13 @@ class TestAutoCoolHysteresis:
         assert e._desired_real_mode() == HVACMode.OFF
         e._unit_command = HVACMode.OFF
 
-        # Drift around in band — must stay OFF
-        for t in (21.5, 22.0, 22.5, 23.0):
+        # Drift up again to 22.75 — must stay OFF (not flicker)
+        for t in (22.25, 22.5, 22.75):
             e._current_temperature = t
-            assert e._desired_real_mode() == HVACMode.OFF, (
-                f"OFF state at {t} (in band) should stay OFF"
-            )
+            assert e._desired_real_mode() == HVACMode.OFF
 
-        # Climb above high → COOL again (one start, not many)
-        e._current_temperature = 23.1
+        # Cross threshold again — second cycle starts cleanly
+        e._current_temperature = 22.8
         assert e._desired_real_mode() == HVACMode.COOL
 
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -329,6 +329,118 @@ class TestAutoCoolOffInBand:
         assert entity._desired_real_mode() == HVACMode.COOL
 
 
+class TestAutoCoolHysteresis:
+    """In-band hysteresis for AUTO + COOL.
+
+    v3.0.0 used a flat threshold at the band edge — the wrapper short-
+    cycled because crossing into the band by 0.1 °C immediately
+    commanded OFF after only ~2 min of useful cooling.  Deployed
+    2026-04-26 and observed live: a 2-minute COOL pulse at 23.0 °C.
+
+    Fix: keep cooling until current drops to the midpoint, then OFF;
+    don't restart until current rises back above high.  Each
+    compressor start now does ~½-band of useful work before stopping,
+    amortising the start-up cost over a meaningful pull.
+    """
+
+    def _entity(self, inside, low=21.0, high=23.0,
+                last_cmd=None, committed=HVACMode.COOL):
+        hass = _make_hass_mock(inside_temp=inside)
+        config = {
+            CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
+            CONF_INSIDE_SENSOR: INSIDE_SENSOR_ID,
+        }
+        entity = _make_entity(hass, config)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_HOME
+        entity._current_temperature = inside
+        entity._preset_ranges[PRESET_HOME] = (low, high)
+        entity._auto_mode = committed
+        entity._unit_command = last_cmd
+        return entity
+
+    def test_keeps_cooling_above_midpoint(self):
+        """COOL state, current still above mid → keep cooling.
+
+        Reproduces the live bug: at 23.0 °C with COOL just sent, v3.0.0
+        flipped to OFF immediately.  Hysteresis says keep going to mid.
+        """
+        for inside in (22.99, 22.5, 22.1):
+            entity = self._entity(inside=inside, last_cmd=HVACMode.COOL)
+            assert entity._desired_real_mode() == HVACMode.COOL, (
+                f"COOL state at {inside} (>mid=22): expected COOL, "
+                f"got {entity._desired_real_mode()}"
+            )
+
+    def test_stops_at_midpoint(self):
+        """COOL state, current ≤ mid → OFF (compressor stops)."""
+        for inside in (22.0, 21.9, 21.5, 21.0):
+            entity = self._entity(inside=inside, last_cmd=HVACMode.COOL)
+            assert entity._desired_real_mode() == HVACMode.OFF, (
+                f"COOL state at {inside} (≤mid=22): expected OFF, "
+                f"got {entity._desired_real_mode()}"
+            )
+
+    def test_off_state_does_not_restart_in_band(self):
+        """OFF state, current still ≤ high → stay OFF (no restart).
+
+        This is the other half of the hysteresis: once OFF, the wrapper
+        does not restart COOL until current rises above the high edge.
+        """
+        for inside in (21.0, 22.0, 22.9, 23.0):
+            entity = self._entity(inside=inside, last_cmd=HVACMode.OFF)
+            assert entity._desired_real_mode() == HVACMode.OFF, (
+                f"OFF state at {inside} (≤high=23): expected OFF, "
+                f"got {entity._desired_real_mode()}"
+            )
+
+    def test_off_state_restarts_above_high(self):
+        """OFF state, current > high → start COOL."""
+        for inside in (23.01, 23.5, 24.0):
+            entity = self._entity(inside=inside, last_cmd=HVACMode.OFF)
+            assert entity._desired_real_mode() == HVACMode.COOL
+
+    def test_first_sync_with_no_prior_command_treats_as_off_state(self):
+        """`_unit_command is None` (first sync) behaves like OFF state:
+        in band → stay OFF; above high → COOL."""
+        e_in_band = self._entity(inside=22.5, last_cmd=None)
+        assert e_in_band._desired_real_mode() == HVACMode.OFF
+        e_above = self._entity(inside=24.0, last_cmd=None)
+        assert e_above._desired_real_mode() == HVACMode.COOL
+
+    def test_full_pull_cycle_minimum_two_starts_per_full_cycle(self):
+        """End-to-end: simulate temp 24 → 22 → 24 → 22 with the wrapper
+        tracking _unit_command.  Verify exactly one COOL start per
+        full cycle (not two from short-cycling at 23)."""
+        # Cycle 1: 24 → start COOL
+        e = self._entity(inside=24.0, last_cmd=HVACMode.OFF)
+        assert e._desired_real_mode() == HVACMode.COOL
+        e._unit_command = HVACMode.COOL  # simulate sync committed COOL
+
+        # Drift down through band — must stay COOL until mid
+        for t in (23.5, 23.0, 22.5, 22.1):
+            e._current_temperature = t
+            assert e._desired_real_mode() == HVACMode.COOL, (
+                f"COOL state at {t} should stay COOL"
+            )
+
+        # Hit mid → OFF
+        e._current_temperature = 22.0
+        assert e._desired_real_mode() == HVACMode.OFF
+        e._unit_command = HVACMode.OFF
+
+        # Drift around in band — must stay OFF
+        for t in (21.5, 22.0, 22.5, 23.0):
+            e._current_temperature = t
+            assert e._desired_real_mode() == HVACMode.OFF, (
+                f"OFF state at {t} (in band) should stay OFF"
+            )
+
+        # Climb above high → COOL again (one start, not many)
+        e._current_temperature = 23.1
+        assert e._desired_real_mode() == HVACMode.COOL
+
+
 class TestAutoHeatNeverOff:
     """HEAT in AUTO retains v2.0.0's "never command OFF" contract.
 


### PR DESCRIPTION
## Summary

v3.0.0 used a flat threshold at the band edge — as soon as current re-entered `[low, high]` from above by any amount, the wrapper commanded OFF.

**Live observation 2026-04-26** (right after v3.0.0 deploy):

> "cool is entering because temp is 23, but it ran for only 2 minutes, and then turn off"

Temp hit the high edge (23.0 °C), wrapper started COOL, temp dropped 0.1 °C back into band, wrapper stopped COOL.  ~2 minutes of compressor runtime, no meaningful cooling pull, start-up cost wasted.

## Fix: hysteresis around the band

Asymmetric thresholds keyed on `_unit_command` (the wrapper''s last sent command):

| `_unit_command` | `current` (in band) | Decision |
|---|---|---|
| `OFF` / `None` | ≤ high | **OFF** (don''t restart at the edge) |
| `OFF` / `None` | > high | **COOL** (start) |
| `COOL` | > mid | **COOL** (keep cooling) |
| `COOL` | ≤ mid | **OFF** (full pull achieved) |

Out-of-band cases unchanged from v3.0.0 / v2.0.0:
- `above high` → COOL (real demand)
- `below low` → COOL (wrong-side; FLIP_DWELL flips committed direction to HEAT after 30 min)

Each compressor start now does ~½ of the comfort band of useful cooling before stopping, amortising the start-up cost over a meaningful pull.

## Tests (83 pass)

New `TestAutoCoolHysteresis` (6 tests):
- `test_keeps_cooling_above_midpoint` — reproduces the live bug exactly: COOL state at 22.99/22.5/22.1 stays COOL.
- `test_stops_at_midpoint` — COOL state at ≤22 → OFF.
- `test_off_state_does_not_restart_in_band` — OFF state at 21/22/22.9/23 → OFF (no premature restart).
- `test_off_state_restarts_above_high` — OFF state at >23 → COOL (start).
- `test_first_sync_with_no_prior_command_treats_as_off_state` — `_unit_command=None` defaults to OFF state.
- `test_full_pull_cycle_minimum_two_starts_per_full_cycle` — end-to-end simulation of 24 → 22 → 24 verifying exactly one COOL start per full cycle.

## Test plan

- [x] `pytest tests/test_climate.py` — 83 green
- [ ] Deploy to live HA at duvall.calvonet.com
- [ ] Confirm COOL pulse length ≥ time-to-half-band (e.g., 23 → 22 should take >> 2 min)
- [ ] Confirm wrapper does not restart COOL until current rises *above* the high edge
- [ ] Watch overnight cycle structure: should see distinct on-cycles (high → mid pulls) separated by long OFF stretches, not 2-min flickers