### PR TITLE
feat: fast-flip on band-edge violation + problems attribute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,6 +443,56 @@ coarser sensors, raise `COOL_RESTART_OFFSET` to at least
 `(sensor_resolution + 0.5 °C)` so the lead headroom is wider than
 one sensor step.
 
+### Two-tier flip logic (v3.1.0)
+
+Direction commitment changes on two timelines, by severity:
+
+1. **Fast-flip — band-edge violation** (immediate).  When the
+   committed direction is the *opposite* of demand AND inside is
+   strictly past the band edge (`HEAT committed & inside > high`,
+   or `COOL committed & inside < low`), flip on the very next
+   sensor tick.  No dwell, no jitter filter — there's no legitimate
+   jitter explanation for inside being past the wrong band edge.
+
+2. **Dwell-flip — sustained margin excursion** (30 min).  When
+   inside crosses `mid ± FLIP_MARGIN` against the committed
+   direction but stays inside the band, the existing 30-min
+   `FLIP_DWELL` logic filters jitter and only commits the flip
+   after sustained pressure.
+
+Live regression 2026-04-26: with HEAT committed (from a stale
+state surviving an integration reload that pre-dated the v3.0.2
+initial-pick fix), inside at 23.3 °C took 30 minutes to flip to
+COOL — during which the wrapper actively heated the hot room.
+The fast-flip catches this on the first sensor tick.
+
+### Problem detection (`problems` attribute)
+
+The wrapper exposes a `problems` extra-state-attribute — a list
+of detected issues, empty when healthy.  Use in dashboards /
+templates: e.g.
+
+```yaml
+- alert: |
+    {% if state_attr('climate.smart_climate', 'problems') | length > 0 %}
+    Smart Climate: {{ state_attr('climate.smart_climate', 'problems') | join(', ') }}
+    {% endif %}
+```
+
+Conditions checked:
+
+| Code | Meaning | Threshold |
+|---|---|---|
+| `inside_sensor_unavailable` / `_unknown` / `_missing` | Inside-temp sensor is unreachable | immediate |
+| `sensor_stale:Nmin` | Inside sensor hasn't updated in N minutes | `SENSOR_STALE_MINUTES` (15) |
+| `real_climate_unavailable` / `_missing` | Wrapped climate device is unreachable | immediate |
+| `out_of_band:Nmin` | AUTO can't keep room in band | `OUT_OF_BAND_ALERT_MINUTES` (30) |
+| `short_cycle:N/h` | COOL starts/hour too high | `SHORT_CYCLE_THRESHOLD_PER_H` (6) |
+
+`out_of_band` only fires in AUTO (manual modes are on the user's
+terms).  `short_cycle` count is a rolling 1-hour window of `OFF→COOL`
+transitions tracked in `_async_sync_real_climate`.
+
 `hvac_action` returns `IDLE` (not `OFF`) on the wrapper whenever
 the unit_command is OFF — distinguishes "AUTO resting" from
 "user turned it off entirely".  Implemented via a `_unit_command`

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -8,6 +8,7 @@ Wraps a physical climate device and adds:
 """
 from __future__ import annotations
 
+import collections
 import datetime
 import logging
 import math
@@ -56,6 +57,9 @@ from .const import (
     MAX_TEMP,
     MIN_TEMP,
     MIN_TEMP_DIFF,
+    OUT_OF_BAND_ALERT_MINUTES,
+    SENSOR_STALE_MINUTES,
+    SHORT_CYCLE_THRESHOLD_PER_H,
     TEMP_STEP,
 )
 
@@ -172,6 +176,13 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # frontend distinguishes "AUTO resting" from "user turned it off".
         self._unit_command: HVACMode | None = None
 
+        # Problem-detection state (surfaced via `problems` attribute).
+        # Updated by sensor / sync callbacks; checked at attribute read.
+        self._out_of_band_since: datetime.datetime | None = None
+        self._cool_start_times: collections.deque[datetime.datetime] = (
+            collections.deque(maxlen=20)
+        )
+
     # ------------------------------------------------------------------
     # ClimateEntity properties
     # ------------------------------------------------------------------
@@ -276,6 +287,16 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
     def target_temperature_step(self) -> float:
         """Return the supported step size for target temperature."""
         return TEMP_STEP
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Surface diagnostic attributes alongside HA's standard ones.
+
+        ``problems`` is a list of detected issues (empty when healthy).
+        Useful for dashboards and templates: e.g. trigger a notification
+        when ``state_attr('climate.smart_climate', 'problems') | length > 0``.
+        """
+        return {"problems": self._detect_problems()}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -429,6 +450,19 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         old_temp = self._current_temperature
         self._current_temperature = new_temp
 
+        # Track sustained out-of-band excursions for problem detection.
+        # Only meaningful in AUTO mode — manual HEAT/COOL/OFF is on the
+        # user's terms.
+        if self._hvac_mode == HVACMode.AUTO:
+            low, high = self._active_range()
+            if new_temp < low or new_temp > high:
+                if self._out_of_band_since is None:
+                    self._out_of_band_since = self._now()
+            else:
+                self._out_of_band_since = None
+        else:
+            self._out_of_band_since = None
+
         # In AUTO preset mode, re-evaluate the real device's mode
         if (
             self._hvac_mode == HVACMode.AUTO
@@ -482,6 +516,67 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
     def _now(self) -> datetime.datetime:
         """Return the current UTC time.  Indirection point for tests."""
         return datetime.datetime.now(datetime.timezone.utc)
+
+    def _detect_problems(self) -> list[str]:
+        """Return a list of detected issues, empty when healthy.
+
+        Checks (in order):
+        - inside-sensor unavailable / unknown / missing
+        - inside-sensor stale (no update for SENSOR_STALE_MINUTES)
+        - real climate device unavailable
+        - sustained out-of-band temperature in AUTO
+        - COOL short-cycling (more than SHORT_CYCLE_THRESHOLD_PER_H starts/h)
+
+        Each problem is a short string code with optional context, e.g.
+        ``out_of_band:42min``, ``short_cycle:8/h``, ``sensor_stale:18min``.
+        """
+        problems: list[str] = []
+        now = self._now()
+
+        # Inside sensor health.
+        inside_state = self.hass.states.get(self._inside_sensor_id)
+        if inside_state is None:
+            problems.append("inside_sensor_missing")
+        elif inside_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None, ""):
+            problems.append(f"inside_sensor_{inside_state.state}")
+        else:
+            try:
+                last = inside_state.last_updated
+                if last.tzinfo is None:
+                    last = last.replace(tzinfo=datetime.timezone.utc)
+                stale_min = (now - last).total_seconds() / 60.0
+                if stale_min > SENSOR_STALE_MINUTES:
+                    problems.append(f"sensor_stale:{int(stale_min)}min")
+            except (AttributeError, TypeError):
+                pass
+
+        # Real climate device health.
+        real_state = self.hass.states.get(self._real_climate_id)
+        if real_state is None:
+            problems.append("real_climate_missing")
+        elif real_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None, ""):
+            problems.append("real_climate_unavailable")
+
+        # Sustained out-of-band in AUTO.  AUTO that can't keep the room
+        # in band over half-hour windows means the unit is undersized,
+        # blocked, or fighting an unmet load — the user should know.
+        if (
+            self._hvac_mode == HVACMode.AUTO
+            and self._out_of_band_since is not None
+        ):
+            duration = (now - self._out_of_band_since).total_seconds() / 60.0
+            if duration > OUT_OF_BAND_ALERT_MINUTES:
+                problems.append(f"out_of_band:{int(duration)}min")
+
+        # Short cycling.  Count COOL starts in the trailing hour; if it's
+        # over the threshold the wrapper is flicking the compressor too
+        # hard, likely from sensor jitter near the band edge.
+        one_hour_ago = now - datetime.timedelta(hours=1)
+        recent = sum(1 for t in self._cool_start_times if t > one_hour_ago)
+        if recent > SHORT_CYCLE_THRESHOLD_PER_H:
+            problems.append(f"short_cycle:{recent}/h")
+
+        return problems
 
     def _desired_real_mode(self) -> HVACMode:
         """Determine which mode (HEAT/COOL/OFF) the real device should be in.
@@ -550,10 +645,35 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             self._pending_flip_since = None
             # fall through to the band-aware unit-command logic below
 
+        # Fast-flip on band-edge violation: when the committed direction
+        # is the *opposite* of what's needed AND the room is past the
+        # band edge, flip immediately — skip FLIP_DWELL.
+        #
+        # The dwell timer (30 min sustained excursion past mid ± FLIP_MARGIN)
+        # is sized for sensor jitter / natural drift around the midpoint.
+        # That's the wrong filter for the case where committed=HEAT but
+        # inside is already > high (or committed=COOL and inside < low):
+        # there's no jitter explanation for that, only a wrong pick or
+        # an external swing the dwell would take 30 min to correct.
+        # During those 30 min the wrapper actively heats a hot room (or
+        # cools a cold one), making the excursion worse.  Live bug
+        # 2026-04-26 (PR #62 fixed the *initial* pick that caused it;
+        # this is the belt-and-suspenders catch for any future scenario
+        # that lands committed-direction at odds with the band).
+        if (
+            (self._auto_mode == HVACMode.HEAT and inside > high)
+            or (self._auto_mode == HVACMode.COOL and inside < low)
+        ):
+            self._auto_mode = (
+                HVACMode.COOL if self._auto_mode == HVACMode.HEAT else HVACMode.HEAT
+            )
+            self._pending_flip_since = None
+
         # Sticky direction-flip evaluation (unchanged from v2.0.0).  Wrong-
         # side / right-side bands have a deadzone in between (mid ± FLIP_MARGIN)
         # where the timer keeps running but is not reset, so sensor jitter
         # near the margin doesn't repeatedly cancel an in-progress flip.
+        # This handles the in-band drift case the fast-flip above doesn't.
         if self._auto_mode == HVACMode.COOL:
             wrong_side = inside <= mid - FLIP_MARGIN
             right_side = inside >= mid
@@ -609,6 +729,13 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             return
 
         real_mode = self._desired_real_mode()
+        # Record COOL transitions for short-cycle detection.  A "start"
+        # is OFF → COOL (or None → COOL on first sync).
+        if (
+            real_mode == HVACMode.COOL
+            and self._unit_command != HVACMode.COOL
+        ):
+            self._cool_start_times.append(self._now())
         # Record the wrapper's intent so hvac_action can surface IDLE for
         # deliberate-OFF (AUTO + OFF inside the comfort band) without
         # re-running _desired_real_mode (which has timer side-effects).

--- a/custom_components/smart_climate/const.py
+++ b/custom_components/smart_climate/const.py
@@ -63,3 +63,11 @@ FLIP_DWELL = 1800  # 30 min
 # 0.1 °C resolution, which is fine.  If you wire a coarser sensor, raise
 # COOL_RESTART_OFFSET to (sensor_resolution + 0.5 °C) or wider.
 COOL_RESTART_OFFSET = 0.75
+
+# Problem-detection thresholds.  Surfaced as the wrapper's `problems`
+# attribute (a list of detected issues, empty when healthy).  Sized
+# generously so transient blips don't fire false alarms; tune down if
+# false-negatives matter more than false-alarms in a given deployment.
+OUT_OF_BAND_ALERT_MINUTES   = 30   # sustained outside [low, high] in AUTO
+SHORT_CYCLE_THRESHOLD_PER_H = 6    # COOL starts/hour above this is "too much"
+SENSOR_STALE_MINUTES        = 15   # no inside-temp update for this long

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -30,6 +30,9 @@ from custom_components.smart_climate.const import (
     FLIP_DWELL,
     FLIP_MARGIN,
     MIN_TEMP_DIFF,
+    OUT_OF_BAND_ALERT_MINUTES,
+    SENSOR_STALE_MINUTES,
+    SHORT_CYCLE_THRESHOLD_PER_H,
 )
 
 
@@ -291,7 +294,8 @@ class TestDesiredRealMode:
                 f"expected HEAT, got {entity._desired_real_mode()}"
             )
 
-        # Outside the band, both directions do work (v2.0.0 unchanged)
+        # Outside the band on the *right* side (committed direction
+        # matches demand): unit command runs the committed direction.
         cool_committed_above = self._entity(inside=high + 1)
         cool_committed_above._auto_mode = HVACMode.COOL
         assert cool_committed_above._desired_real_mode() == HVACMode.COOL
@@ -300,15 +304,19 @@ class TestDesiredRealMode:
         heat_committed_below._auto_mode = HVACMode.HEAT
         assert heat_committed_below._desired_real_mode() == HVACMode.HEAT
 
-        # Wrong-side excursions pass committed direction through (v2.0.0).
-        # The FLIP_DWELL timer flips _auto_mode after sustained excursion.
+        # Wrong-side band-edge excursions: fast-flip to the correct
+        # direction and run *that* direction's unit command.  Skips the
+        # 30-min FLIP_DWELL the v2.0.0 / v3.0.0 wrong-side passthrough
+        # would have waited on.  See TestFastFlipOnBandViolation.
         cool_committed_below = self._entity(inside=low - 1)
         cool_committed_below._auto_mode = HVACMode.COOL
-        assert cool_committed_below._desired_real_mode() == HVACMode.COOL
+        assert cool_committed_below._desired_real_mode() == HVACMode.HEAT
+        assert cool_committed_below._auto_mode == HVACMode.HEAT
 
         heat_committed_above = self._entity(inside=high + 1)
         heat_committed_above._auto_mode = HVACMode.HEAT
-        assert heat_committed_above._desired_real_mode() == HVACMode.HEAT
+        assert heat_committed_above._desired_real_mode() == HVACMode.COOL
+        assert heat_committed_above._auto_mode == HVACMode.COOL
 
 
 class TestAutoCoolOffInBand:
@@ -383,16 +391,13 @@ class TestAutoCoolOffInBand:
         entity = self._entity(inside=23.5, committed=HVACMode.COOL)
         assert entity._desired_real_mode() == HVACMode.COOL
 
-    def test_cool_below_low_runs_cool_v2_compat(self):
-        """COOL committed, below band → COOL passes through (v2.0.0).
-
-        We deliberately do NOT short-circuit to OFF in the wrong-side
-        case.  The user's instruction was: OFF only when tending to cool
-        inside the band.  Wrong-side COOL is rare and the FLIP_DWELL
-        timer flips committed direction to HEAT after 30 min.
-        """
+    def test_cool_below_low_fast_flips_to_heat(self):
+        """COOL committed + inside < low: fast-flip to HEAT immediately
+        (no 30-min dwell wait).  Replaces the v2.0.0 / v3.0.0 wrong-
+        side COOL passthrough — see TestFastFlipOnBandViolation."""
         entity = self._entity(inside=20.5, committed=HVACMode.COOL)
-        assert entity._desired_real_mode() == HVACMode.COOL
+        assert entity._desired_real_mode() == HVACMode.HEAT
+        assert entity._auto_mode == HVACMode.HEAT
 
 
 class TestAutoCoolHysteresis:
@@ -586,12 +591,13 @@ class TestAutoHeatNeverOff:
         entity = self._entity(inside=20.5)
         assert entity._desired_real_mode() == HVACMode.HEAT
 
-    def test_heat_above_high_stays_heat_v2_compat(self):
-        """HEAT committed + warm room → HEAT (wrong-side; FLIP_DWELL
-        eventually commits direction to COOL).  Pass-through matches
-        v2.0.0; no early OFF short-circuit."""
+    def test_heat_above_high_fast_flips_to_cool(self):
+        """HEAT committed + inside > high: fast-flip to COOL immediately
+        (no 30-min dwell wait).  Replaces the v2.0.0 / v3.0.0 wrong-
+        side HEAT passthrough — see TestFastFlipOnBandViolation."""
         entity = self._entity(inside=23.5)
-        assert entity._desired_real_mode() == HVACMode.HEAT
+        assert entity._desired_real_mode() == HVACMode.COOL
+        assert entity._auto_mode == HVACMode.COOL
 
 
 class TestHvacActionInAutoOff:
@@ -834,6 +840,109 @@ class TestStickyAutoMode:
         advance(FLIP_DWELL - 120)
         entity._desired_real_mode()
         assert entity._auto_mode == HVACMode.HEAT
+
+
+class TestFastFlipOnBandViolation:
+    """Fast-flip catches the case the dwell logic is too slow for:
+    committed direction is the *opposite* of demand AND inside is past
+    the band edge.  No legitimate jitter explanation, so flip
+    immediately on the first such tick — skip FLIP_DWELL entirely.
+
+    Live regression 2026-04-26: with HEAT committed (from a bad initial
+    pick or stale state) and inside at 23.3 (above high=23), the dwell
+    logic took 30 minutes to flip — during which the wrapper actively
+    heated a hot room, pushing it further over the high edge.  The
+    initial-pick fix in PR #62 prevents the bad pick; this fast-flip
+    catches *any* future scenario that lands committed-direction at
+    odds with the band (manual override, sudden outside event, etc.).
+    """
+
+    def _entity(self, inside, committed, low=21.0, high=23.0):
+        hass = _make_hass_mock(inside_temp=inside)
+        config = {
+            CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
+            CONF_INSIDE_SENSOR: INSIDE_SENSOR_ID,
+        }
+        entity = _make_entity(hass, config)
+        entity._hvac_mode = HVACMode.AUTO
+        entity._preset_mode = PRESET_HOME
+        entity._current_temperature = inside
+        entity._preset_ranges[PRESET_HOME] = (low, high)
+        entity._auto_mode = committed
+        entity._pending_flip_since = None
+        now, _ = _fake_clock()
+        entity._now = now
+        return entity
+
+    def test_heat_committed_inside_above_high_flips_immediately(self):
+        """HEAT committed + inside > high → flip to COOL on first tick.
+
+        Reproduces the live 2026-04-26 bug at 23.3 °C (above high=23).
+        Pre-fix: dwell timer waited 30 min before flipping.
+        Post-fix: flip on the first sensor tick, no waiting.
+        """
+        entity = self._entity(inside=23.3, committed=HVACMode.HEAT)
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL, (
+            "Fast-flip must fire on first tick when committed=HEAT and "
+            "inside is above high — no dwell tolerable"
+        )
+        assert entity._pending_flip_since is None
+
+    def test_cool_committed_inside_below_low_flips_immediately(self):
+        """Mirror: COOL committed + inside < low → flip to HEAT immediately."""
+        entity = self._entity(inside=20.5, committed=HVACMode.COOL)
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.HEAT
+        assert entity._pending_flip_since is None
+
+    def test_no_fast_flip_at_exact_band_edge(self):
+        """Inside exactly at high (or low) is not a violation — fast-flip
+        only fires for strictly past-the-edge.  At the edge, the dwell
+        logic still applies as the milder corrective."""
+        e_high = self._entity(inside=23.0, committed=HVACMode.HEAT)
+        e_high._desired_real_mode()
+        assert e_high._auto_mode == HVACMode.HEAT, (
+            "Fast-flip must NOT fire at exactly the high edge; only > high"
+        )
+
+        e_low = self._entity(inside=21.0, committed=HVACMode.COOL)
+        e_low._desired_real_mode()
+        assert e_low._auto_mode == HVACMode.COOL
+
+    def test_no_fast_flip_in_band(self):
+        """In-band excursion past FLIP_MARGIN but not past band edge:
+        let the dwell handle it (the case it was designed for)."""
+        # HEAT committed, inside in [mid+FLIP_MARGIN, high) — this is the
+        # dwell's territory, not fast-flip's.
+        entity = self._entity(inside=22.6, committed=HVACMode.HEAT)
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.HEAT, (
+            "In-band past FLIP_MARGIN but not past high: dwell, not fast-flip"
+        )
+
+    def test_no_fast_flip_when_committed_direction_matches_demand(self):
+        """COOL committed + inside > high: do not flip (this is the
+        right direction; the unit command logic returns COOL)."""
+        entity = self._entity(inside=23.5, committed=HVACMode.COOL)
+        entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
+
+        # HEAT committed + inside < low: do not flip (correct direction).
+        entity2 = self._entity(inside=20.5, committed=HVACMode.HEAT)
+        entity2._desired_real_mode()
+        assert entity2._auto_mode == HVACMode.HEAT
+
+    def test_fast_flip_then_unit_command_runs_correct_direction(self):
+        """End-to-end: HEAT committed + inside=23.3 → fast-flip to COOL
+        → unit command returns COOL (since inside > high under COOL)."""
+        entity = self._entity(inside=23.3, committed=HVACMode.HEAT)
+        result = entity._desired_real_mode()
+        assert entity._auto_mode == HVACMode.COOL
+        assert result == HVACMode.COOL, (
+            "Same tick that flips must produce the correct unit command — "
+            "no half-tick limbo where the wrong direction still drives"
+        )
 
 
 class TestLeavingAutoClearsCommitment:
@@ -1373,6 +1482,166 @@ def test_supported_presets_list():
     assert PRESET_AWAY in SUPPORTED_PRESETS
     assert PRESET_NONE in SUPPORTED_PRESETS
     assert len(SUPPORTED_PRESETS) == 4
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – problem detection (`problems` attribute)
+# ---------------------------------------------------------------------------
+
+class TestProblemDetection:
+    """The `problems` extra_state_attribute lists detected issues —
+    empty when healthy.  Used by dashboards / templates to surface
+    actionable notifications instead of silent failure modes."""
+
+    def _entity(self, *, hvac_mode=HVACMode.AUTO, inside=22.0,
+                low=21.0, high=23.0, real_state=HVACMode.OFF.value,
+                inside_state_value=None, inside_last_updated=None):
+        # inside_state_value overrides the sensor's reported state string;
+        # when None the helper uses str(inside).
+        if inside_state_value is None:
+            inside_state_value = str(inside)
+        hass = MagicMock()
+        hass.config.units.temperature_unit = "°C"
+
+        sensor_state = MagicMock()
+        sensor_state.state = inside_state_value
+        sensor_state.last_updated = (
+            inside_last_updated
+            or datetime.datetime(2026, 4, 26, 22, 0, tzinfo=datetime.timezone.utc)
+        )
+
+        real = MagicMock()
+        real.state = real_state
+        real.attributes = {"hvac_action": None, "temperature": None}
+
+        def _get(eid):
+            if eid == REAL_CLIMATE_ID: return real
+            if eid == INSIDE_SENSOR_ID: return sensor_state
+            return None
+        hass.states.get = _get
+        hass.services.async_call = AsyncMock()
+        hass.async_create_task = MagicMock()
+
+        config = {
+            CONF_REAL_CLIMATE: REAL_CLIMATE_ID,
+            CONF_INSIDE_SENSOR: INSIDE_SENSOR_ID,
+        }
+        entity = _make_entity(hass, config)
+        entity._hvac_mode = hvac_mode
+        entity._preset_mode = PRESET_HOME
+        entity._current_temperature = inside
+        entity._preset_ranges[PRESET_HOME] = (low, high)
+        # Pin _now to the sensor's last_updated so "fresh" is the default.
+        fixed_now = sensor_state.last_updated
+        entity._now = lambda: fixed_now
+        return entity, sensor_state, real
+
+    def test_healthy_returns_empty_list(self):
+        entity, _, _ = self._entity()
+        assert entity._detect_problems() == []
+        # And the public attribute echoes the same.
+        assert entity.extra_state_attributes == {"problems": []}
+
+    def test_inside_sensor_unavailable(self):
+        entity, sensor, _ = self._entity(inside_state_value="unavailable")
+        problems = entity._detect_problems()
+        assert any(p.startswith("inside_sensor_") for p in problems), problems
+
+    def test_inside_sensor_stale(self):
+        # Sensor last updated 30 min before "now".
+        now = datetime.datetime(2026, 4, 26, 22, 0,
+                                tzinfo=datetime.timezone.utc)
+        old = now - datetime.timedelta(minutes=SENSOR_STALE_MINUTES + 5)
+        entity, _, _ = self._entity(inside_last_updated=old)
+        entity._now = lambda: now
+        problems = entity._detect_problems()
+        assert any(p.startswith("sensor_stale:") for p in problems), problems
+
+    def test_real_climate_unavailable(self):
+        entity, _, real = self._entity()
+        real.state = "unavailable"
+        problems = entity._detect_problems()
+        assert "real_climate_unavailable" in problems
+
+    def test_out_of_band_under_threshold_not_reported(self):
+        """Brief out-of-band excursion below threshold: no alert yet."""
+        entity, _, _ = self._entity(inside=24.0)  # above high=23
+        # Pretend we crossed out 5 min ago.
+        now = datetime.datetime(2026, 4, 26, 22, 0,
+                                tzinfo=datetime.timezone.utc)
+        entity._now = lambda: now
+        entity._out_of_band_since = now - datetime.timedelta(minutes=5)
+        assert all(not p.startswith("out_of_band") for p in entity._detect_problems())
+
+    def test_out_of_band_sustained_reports(self):
+        """Sustained out-of-band past threshold: alert."""
+        entity, _, _ = self._entity(inside=24.0)
+        now = datetime.datetime(2026, 4, 26, 22, 0,
+                                tzinfo=datetime.timezone.utc)
+        entity._now = lambda: now
+        entity._out_of_band_since = (
+            now - datetime.timedelta(minutes=OUT_OF_BAND_ALERT_MINUTES + 5)
+        )
+        problems = entity._detect_problems()
+        assert any(p.startswith("out_of_band:") for p in problems), problems
+
+    def test_out_of_band_only_in_auto(self):
+        """Manual HEAT/COOL/OFF doesn't fire out-of-band alerts — the
+        user is on their own terms there."""
+        entity, _, _ = self._entity(hvac_mode=HVACMode.HEAT, inside=24.0)
+        # Even with stale out_of_band_since, manual mode shouldn't alert.
+        entity._out_of_band_since = (
+            entity._now() - datetime.timedelta(minutes=60)
+        )
+        # Force the AUTO gate by switching: in manual mode, the wrapper
+        # also wouldn't track _out_of_band_since via _on_inside_sensor_update.
+        # We rely on the gate inside _detect_problems.
+        assert all(not p.startswith("out_of_band") for p in entity._detect_problems())
+
+    def test_short_cycle_under_threshold_not_reported(self):
+        entity, _, _ = self._entity()
+        now = entity._now()
+        # SHORT_CYCLE_THRESHOLD_PER_H starts in the last hour: not over.
+        for i in range(SHORT_CYCLE_THRESHOLD_PER_H):
+            entity._cool_start_times.append(
+                now - datetime.timedelta(minutes=i * 5)
+            )
+        assert all(not p.startswith("short_cycle") for p in entity._detect_problems())
+
+    def test_short_cycle_over_threshold_reports(self):
+        entity, _, _ = self._entity()
+        now = entity._now()
+        # SHORT_CYCLE_THRESHOLD_PER_H + 2 starts in the last hour: over.
+        for i in range(SHORT_CYCLE_THRESHOLD_PER_H + 2):
+            entity._cool_start_times.append(
+                now - datetime.timedelta(minutes=i * 3)
+            )
+        problems = entity._detect_problems()
+        assert any(p.startswith("short_cycle:") for p in problems), problems
+
+    def test_short_cycle_window_is_trailing_hour(self):
+        """Old starts (>1h ago) are excluded from the rolling count."""
+        entity, _, _ = self._entity()
+        now = entity._now()
+        # 5 starts > 1h ago — should not count.
+        for i in range(5):
+            entity._cool_start_times.append(
+                now - datetime.timedelta(hours=2, minutes=i)
+            )
+        # 2 starts in the last hour — well under threshold.
+        for i in range(2):
+            entity._cool_start_times.append(
+                now - datetime.timedelta(minutes=i * 5)
+            )
+        assert all(not p.startswith("short_cycle") for p in entity._detect_problems())
+
+    def test_multiple_problems_compose(self):
+        """Independent issues stack; we don't short-circuit at the first."""
+        entity, _, real = self._entity(inside_state_value="unavailable")
+        real.state = "unavailable"
+        problems = entity._detect_problems()
+        assert any(p.startswith("inside_sensor_") for p in problems)
+        assert "real_climate_unavailable" in problems
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related additions, motivated by live behaviour 2026-04-26 where the wrapper waited 30 minutes (`FLIP_DWELL`) before flipping HEAT→COOL after a stale wrong-direction commitment — while the unit actively heated a 23.3 °C room.

PR #62 fixed the *initial pick* that caused the bad commitment in the first place.  This PR adds two complementary safety nets:

1. **Fast-flip on band-edge violation** — catches any future bad commitment regardless of source.
2. **`problems` attribute** — surfaces situations like the 30-min "actively heating a hot room" silently failing.

## Fast-flip on band-edge violation

When the committed direction is the *opposite* of demand AND inside is strictly past the band edge, flip on the very next sensor tick:

| Committed | Inside | Action |
|---|---|---|
| HEAT | `> high` | flip to COOL immediately |
| COOL | `< low` | flip to HEAT immediately |

No `FLIP_DWELL` wait.  The 30-min dwell is sized for sensor jitter near the midpoint — it''s the wrong filter when the room is already past the wrong band edge.  No legitimate jitter explanation, only a wrong commitment to correct.

This **replaces** the v2.0.0 / v3.0.0 wrong-side passthrough that returned the committed direction (heating a hot room, cooling a cold one) until dwell elapsed.

Belt-and-suspenders to PR #62: catches any future bad commitment from stale state across reloads, manual override, or sudden outside event.

## `problems` attribute

New extra-state-attribute `problems` lists detected issues — empty list `[]` when healthy.  Use in dashboards / templates:

```yaml
{% if state_attr(''climate.smart_climate'', ''problems'') %}
  ⚠ {{ state_attr(''climate.smart_climate'', ''problems'') | join(''; '') }}
{% endif %}
```

Conditions checked:

| Code | Meaning | Threshold |
|---|---|---|
| `inside_sensor_unavailable` / `_unknown` / `_missing` | Inside-temp sensor is unreachable | immediate |
| `sensor_stale:Nmin` | Inside sensor hasn''t updated in N minutes | `SENSOR_STALE_MINUTES` (15) |
| `real_climate_unavailable` / `_missing` | Wrapped climate device is unreachable | immediate |
| `out_of_band:Nmin` | AUTO can''t keep room in band for N minutes | `OUT_OF_BAND_ALERT_MINUTES` (30) |
| `short_cycle:N/h` | COOL starts/hour above threshold | `SHORT_CYCLE_THRESHOLD_PER_H` (6) |

`out_of_band` only fires in AUTO (manual modes are on the user''s terms).  `short_cycle` is a rolling 1-hour window of `OFF→COOL` transitions.

State tracked alongside existing fields:
- `_out_of_band_since` — set / cleared in `_on_inside_sensor_update` (AUTO-only)
- `_cool_start_times` (`deque`) — appended on `OFF→COOL` transitions in `_async_sync_real_climate`

## Tests (103 pass)

- **`TestFastFlipOnBandViolation`** (6 tests):
  - HEAT committed + above high → flip to COOL immediately (regression for the live 23.3 °C bug)
  - COOL committed + below low → flip to HEAT immediately
  - No fast-flip at exactly the band edge (only strictly past)
  - No fast-flip in band past `FLIP_MARGIN` (let dwell handle it)
  - No fast-flip when committed direction matches demand
  - End-to-end: same tick that flips returns the correct unit command
- **`TestProblemDetection`** (11 tests): healthy returns `[]`, inside-sensor unavailable, sensor-stale, real-climate unavailable, out-of-band under/over threshold, AUTO-only gate, short-cycle under/over threshold, rolling window, multiple problems compose.
- **3 existing tests rebased** from v2.0.0 wrong-side passthrough (`test_cool_below_low_runs_cool_v2_compat`, `test_heat_above_high_stays_heat_v2_compat`, the wrong-side block of `test_auto_cool_returns_off_when_inside_band`) to assert the new fast-flip behaviour.

## Constants added (tunable)

```python
# const.py
OUT_OF_BAND_ALERT_MINUTES   = 30
SHORT_CYCLE_THRESHOLD_PER_H = 6
SENSOR_STALE_MINUTES        = 15
```

## Test plan

- [x] `pytest tests/test_climate.py` — 103 green
- [ ] Deploy to live HA at duvall.calvonet.com
- [ ] Manually toggle wrapper to `heat` mode briefly while inside ≥ 23 → switch to `auto` → verify flip to COOL is *immediate*, not 30 min
- [ ] Wait through a normal cycle: confirm `problems == []`
- [ ] Force a fault (e.g., disable inside-temp sensor) → confirm `problems` gains `inside_sensor_unavailable`
- [ ] Run a tight COOL band (e.g., temporarily lower `COOL_RESTART_OFFSET`) and confirm `short_cycle:N/h` fires when starts > 6/h