### PR TITLE
docs: add state-machine diagrams + refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A HACS-compatible custom component for Home Assistant that turns any climate dev
 ## Features
 
 - **Comfort Presets** – Home, Sleep, Away, and Manual modes with independently configurable temperature ranges (low/high setpoints).
-- **Auto Heat/Cool Switching** – In AUTO mode the thermostat automatically switches the real device between heating and cooling as the inside temperature drifts outside the comfort band.
-- **Outside Temperature Awareness** – When an optional outdoor sensor is configured, it is used as an additional signal for smarter mode decisions when the inside temperature is already within range.
+- **Auto Heat/Cool Switching** – Sticky direction commitment with two-tier flip logic (immediate fast-flip on band-edge violations + 30-min dwell-flip for sustained excursions).
+- **In-band COOL hysteresis with deliberate-OFF** – Stops the inverter min-frequency floor from pumping unwanted cold air; COOL pulses run from `mid + 0.75 °C` down to `mid`, OFF in between.  See [`docs/state-machine.md`](docs/state-machine.md).
+- **Problem detection** – `problems` attribute lists detected issues (sensor unavailable / stale, sustained out-of-band, short-cycling) for dashboards and notifications.
 - **State Restoration** – Thermostat state (mode, preset, setpoints) survives Home Assistant restarts.
 - **HACS Compatible** – Install and update via the Home Assistant Community Store.
 - **UI Configuration** – Set up via the Home Assistant Integrations UI; adjust preset temperatures via the Options flow.
@@ -38,7 +39,7 @@ A HACS-compatible custom component for Home Assistant that turns any climate dev
    | **Thermostat Name** | ✅ | Friendly name for the new thermostat entity |
    | **Climate Device** | ✅ | The real/dumb climate entity to control (e.g. `climate.heatpump`) |
    | **Inside Temperature Sensor** | ✅ | Sensor entity for the indoor temperature |
-   | **Outside Temperature Sensor** | ❌ | Optional sensor for smarter auto mode decisions |
+   | **Outside Temperature Sensor** | ❌ | Optional sensor — tracked for display and future use (free-cooling detection, forecast preconditioning).  No longer consulted for the AUTO direction pick (see [v3.0.2 changelog](CHANGELOG.md)). |
 
 ### Configure preset temperatures
 
@@ -52,17 +53,40 @@ After setup, click **Configure** on the integration card (or go to **Options**) 
 
 ## How It Works
 
-### AUTO mode (EcoBee-like behaviour)
+### AUTO mode
 
-When the thermostat is in AUTO mode and a comfort preset is active:
+The thermostat maintains a sticky **direction commitment** (HEAT or COOL) that
+flips on demand mismatch, and derives a per-tick **unit command** (HEAT, COOL,
+or OFF) from that direction plus the current inside temperature.
 
-1. If inside temperature **< low setpoint** → switch real device to **HEAT**
-2. If inside temperature **> high setpoint** → switch real device to **COOL**
-3. If inside temperature is **within range**:
-   - With an outside sensor: warm outside → **COOL**; cold outside → **HEAT**
-   - Without an outside sensor: above midpoint → **COOL**; below midpoint → **HEAT**
+- **Initial pick** when entering AUTO: `inside < midpoint → HEAT, otherwise COOL`.
+- **HEAT committed** runs HEAT continuously; the unit modulates to a true
+  compressor idle when no demand.
+- **COOL committed** uses **hysteresis around the band**: starts cooling when
+  current rises above `mid + COOL_RESTART_OFFSET` (default 22.75 °C for the
+  21-23 home preset), stops at `mid` (22 °C).  The 0.25 °C between the
+  restart threshold and the high edge is response-lag headroom — by the time
+  current would otherwise hit the high edge, COOL flow is already pulling
+  the room down.  `hvac_action` reads `idle` while in deliberate-OFF.
+- **Direction flips** on demand mismatch happen via two mechanisms: an
+  immediate **fast-flip** when inside is past the wrong band edge, and a
+  30-min **dwell-flip** for sustained excursions in band.
 
-The real device's setpoint is always kept at the **midpoint** of the active preset range.
+📐 **See [`docs/state-machine.md`](docs/state-machine.md) for the full state
+diagrams, decision flowchart, and design rationale.**
+
+### Problem detection
+
+The wrapper exposes a `problems` extra-state-attribute — a list of detected
+issues (empty list `[]` when healthy).  Conditions checked: inside-sensor
+unavailable / stale, real-device unavailable, sustained out-of-band in AUTO,
+COOL short-cycling.  Use in templates / dashboards:
+
+```jinja
+{% if state_attr('climate.smart_climate', 'problems') %}
+  ⚠ {{ state_attr('climate.smart_climate', 'problems') | join('; ') }}
+{% endif %}
+```
 
 ### Manual mode (PRESET_NONE)
 
@@ -71,7 +95,10 @@ The real device's setpoint is always kept at the **midpoint** of the active pres
 
 ### External changes
 
-If the real device's setpoint is changed externally (e.g., via a physical remote or another automation) by more than 0.5 °C, the smart thermostat automatically switches to **Manual** mode to avoid conflicting with the external change.
+If the real device's setpoint is changed externally (e.g., via a physical
+remote or another automation) by more than 0.5 °C, the smart thermostat
+automatically switches to **Manual** mode to avoid conflicting with the
+external change.
 
 ## Inspiration
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1,0 +1,201 @@
+# Smart Climate — AUTO mode state machine
+
+Reference for the AUTO-mode behavior of `climate.smart_climate` as of
+**v3.1.0**.  Two layers compose:
+
+1. **Direction commitment** (`_auto_mode`) — sticky HEAT or COOL choice
+   that flips on demand mismatch.
+2. **Unit command** — the actual mode sent to the wrapped device on each
+   sensor tick, derived from the committed direction and current
+   temperature.
+
+Other HVAC modes (`OFF`, `HEAT`, `COOL`) pass through to the wrapped
+device unchanged; the state machines below only apply when the wrapper
+is in `AUTO`.
+
+---
+
+## Layer 1 — Direction commitment
+
+`_auto_mode` is `None` after init / leaving AUTO.  On the first sensor
+tick in AUTO it commits to either `HEAT` or `COOL` based on inside-vs-
+midpoint of the active comfort band.  Once committed, it flips only on
+genuine demand mismatch — by one of two mechanisms:
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Uninitialized: __init__\n/ leave AUTO
+    Uninitialized --> HEAT: inside &lt; mid
+    Uninitialized --> COOL: inside ≥ mid
+
+    HEAT --> COOL: fast-flip\n(inside &gt; high)
+    COOL --> HEAT: fast-flip\n(inside &lt; low)
+
+    HEAT --> COOL: dwell-flip\n(inside ≥ mid + FLIP_MARGIN\nfor FLIP_DWELL = 30 min)
+    COOL --> HEAT: dwell-flip\n(inside ≤ mid − FLIP_MARGIN\nfor FLIP_DWELL = 30 min)
+
+    HEAT --> [*]: leave AUTO
+    COOL --> [*]: leave AUTO
+```
+
+### Why two flip mechanisms
+
+`FLIP_DWELL = 30 min` is sized for **sensor jitter / natural drift near
+the midpoint**.  When inside oscillates around `mid ± FLIP_MARGIN`,
+30-minute sustained pressure tells you "this is real demand, not noise".
+
+But the dwell is the wrong filter when inside is **already past the
+band edge** — there's no jitter explanation for `inside > high` while
+HEAT is committed.  That's a wrong commitment, not noise.  Fast-flip
+catches it on the very next sensor tick.
+
+| Mechanism | Trigger | Latency |
+|---|---|---|
+| **Fast-flip** | Wrong direction + inside past band edge (`HEAT & inside > high`, or `COOL & inside < low`) | Immediate (next sensor tick) |
+| **Dwell-flip** | Wrong direction + inside past `mid ± FLIP_MARGIN` but still in band | 30 min sustained excursion |
+
+### Initial-pick rule (`_auto_mode == None`)
+
+Inside-vs-midpoint, full stop.  Outside sensor is **not** consulted —
+empirically the outside reading doesn't correlate with the building's
+thermodynamics in this deployment, and using it caused live HEAT-at-23
+bugs (see [PR #62](https://github.com/HomeOps/HASS-Smart-Climate/pull/62)).
+Outside sensor remains a valid config option for display / future use.
+
+---
+
+## Layer 2 — Unit command (per-tick decision)
+
+Given a committed direction and the current inside temperature, what
+mode does the wrapper send to the wrapped device?
+
+### `_auto_mode == HEAT`
+
+Always **`HEAT`**.  v2.0.0 contract preserved: on this Midea inverter
+the unit modulates HEAT down to a true compressor idle when no demand,
+so commanding OFF (and absorbing the start-up cost on the next call
+for heat) costs more than just letting it sit.
+
+### `_auto_mode == COOL`
+
+Asymmetric — the in-band hysteresis is what stops the COOL minimum-
+frequency floor from pumping unwanted cold air:
+
+```mermaid
+flowchart TD
+    Start([inside, _auto_mode = COOL]) --> AboveBand{inside &gt; high<br/>or inside &lt; low?}
+    AboveBand -->|Yes,<br/>real demand| RunCool[Send <b>COOL</b>]
+    AboveBand -->|No, in band| WasCool{Last command<br/>was COOL?}
+    WasCool -->|Yes| AboveMid{inside &gt; mid?}
+    AboveMid -->|Yes,<br/>keep cooling| RunCool
+    AboveMid -->|No,<br/>full pull achieved| RunOff[Send <b>OFF</b><br/><i>(deliberate-OFF)</i>]
+    WasCool -->|No / None| AboveRestart{inside &gt; mid<br/>+ COOL_RESTART_OFFSET?}
+    AboveRestart -->|Yes,<br/>start next pull| RunCool
+    AboveRestart -->|No,<br/>stay quiet| RunOff
+```
+
+### Why hysteresis
+
+Without asymmetric thresholds, the wrapper short-cycles at the band
+edge: temp hits `high`, COOL runs briefly, temp drops 0.1 °C, OFF
+fires.  The cycle does no useful cooling and wastes compressor starts.
+
+The fix uses two thresholds keyed on the wrapper's last command:
+
+| State | Restart at | Stop at | Per-cycle pull |
+|---|---|---|---|
+| Last was COOL | (already cooling) | `inside ≤ mid` | `mid + RESTART_OFFSET → mid` |
+| Last was OFF / None | `inside > mid + RESTART_OFFSET` | (already off) | (waits for restart trigger) |
+
+For the default home preset (`[21, 23]`, `mid = 22`,
+`COOL_RESTART_OFFSET = 0.75`):
+
+```
+   COOL      ░░░░░░░░░░░░░░░░░░░░░░░░░ ← mid + RESTART_OFFSET = 22.75
+                                          (restart threshold)
+                                          ┌── 0.25 °C lag headroom
+                                          │
+   ════════════════════════════════════ ← high = 23
+                                          │
+                                          └── room must NOT exceed
+                                              this in steady state
+   COOL      ░░░░░░░░░░░░░░░░░░░░░░░░░ ← mid = 22 (stop threshold)
+   pulse:    ┃         ┃    ↑
+             stop      restart
+             (mid)     (mid + 0.75)
+```
+
+The 0.25 °C between the restart threshold (22.75) and the high edge
+(23) is the unit's **response-lag headroom** — compressor ramp + air
+circulation time.  By the time current would otherwise hit 23, COOL
+flow is already pulling the room down.
+
+> **Requires a sub-degree (decimal) inside-temp sensor.**  A whole-
+> degree sensor jumps `22 → 23` and skips the 22.75 threshold,
+> defeating the lead.  This deployment uses Aeotec Multisensor 7
+> (0.1 °C resolution).  For coarser sensors, raise
+> `COOL_RESTART_OFFSET` to at least `(sensor_resolution + 0.5 °C)`.
+
+### Why HEAT doesn't need the same hysteresis
+
+The Midea unit modulates HEAT down to a true compressor idle when no
+demand — likely because in HEAT the indoor coil is the hot side, so
+refrigerant migrates outdoors when stopped (benign, no slug-on-restart
+risk).  COOL inverts that geometry, so the firmware holds a minimum
+frequency to prevent slugging.  The wrapper provides the idle the unit
+won't, but only where it's needed.
+
+See [`CLAUDE.md`](../CLAUDE.md#why-the-asymmetry-exists-refined-theory)
+for the refined theory and the design history.
+
+---
+
+## Composing the layers
+
+Per sensor tick:
+
+1. If `_auto_mode is None`: pick HEAT or COOL by inside-vs-mid.
+2. **Fast-flip check**: if committed direction is wrong AND inside is
+   past the band edge, flip `_auto_mode` immediately.
+3. **Dwell-flip check**: update `_pending_flip_since` based on `mid ±
+   FLIP_MARGIN` deviation; flip `_auto_mode` if sustained for 30 min.
+4. **Unit command**: derive HEAT / COOL / OFF from the (possibly just-
+   flipped) `_auto_mode` per Layer 2.
+5. **Send to device**: only call `set_temperature` / `set_hvac_mode`
+   when the unit's reported state differs from the desired one.
+
+The wrapper exposes its decision via `hvac_action`:
+
+| Wrapper state | `hvac_action` |
+|---|---|
+| Active mode → unit reports `cooling` / `heating` | mirrors the unit |
+| AUTO + COOL committed + in-band → unit OFF | **`idle`** (deliberate-OFF) |
+| User-commanded OFF | `off` |
+
+---
+
+## Problem detection (`problems` attribute)
+
+The wrapper continuously checks for failure modes the state machine
+itself can't fix.  See [`CLAUDE.md` → Problem detection](../CLAUDE.md#problem-detection-problems-attribute)
+for the conditions and thresholds.
+
+`problems` is a list of short codes — empty `[]` when healthy, e.g.
+`["out_of_band:42min", "short_cycle:8/h"]` when not.  Templates can
+key off `length > 0` for notifications.
+
+---
+
+## Constants
+
+All thresholds live in [`const.py`](../custom_components/smart_climate/const.py):
+
+| Constant | Default | Purpose |
+|---|---|---|
+| `FLIP_MARGIN` | 0.5 °C | Past midpoint to count as wrong-side |
+| `FLIP_DWELL` | 1800 s (30 min) | Sustained-excursion threshold for dwell-flip |
+| `COOL_RESTART_OFFSET` | 0.75 °C | Above mid where COOL restarts (lead the high edge) |
+| `OUT_OF_BAND_ALERT_MINUTES` | 30 | When AUTO can't keep room in band |
+| `SHORT_CYCLE_THRESHOLD_PER_H` | 6 | COOL starts/h above this is a problem |
+| `SENSOR_STALE_MINUTES` | 15 | Inside-sensor freshness threshold |


### PR DESCRIPTION
## Summary

Documentation for the AUTO-mode behaviour as of v3.1.0.

### New file: `docs/state-machine.md`

Two mermaid diagrams covering the layered design:

1. **Direction commitment (`stateDiagram-v2`)** — `_auto_mode` lifecycle: initial pick (inside vs midpoint), fast-flip (band-edge violation, immediate), dwell-flip (`mid ± FLIP_MARGIN` for 30 min).
2. **Unit command (`flowchart`)** — per-tick decision for `COOL` committed: above-band runs COOL, in-band uses hysteresis keyed on last command, with the 0.25 °C lead-headroom between `mid + 0.75` and `high`.

Plus an ASCII visualisation of the hysteresis band, the sub-degree-sensor requirement, link to `CLAUDE.md` for design history, and a constants table.

### `README.md` refresh

- Features list: replace stale "Outside Temperature Awareness" with current capabilities (sticky AUTO + fast-flip, COOL hysteresis with deliberate-OFF, problems attribute).
- "How It Works" rewritten to match v3.1.0 with link to the new state-machine doc.
- Outside-sensor row notes its v3.0.2 status (tracked but not consulted for the AUTO direction pick).

### Why a separate file

Keeps the README quick-start oriented and separates user-facing docs from `CLAUDE.md` (which is more of an agent-facing design doc / changelog).

## Test plan

- [x] Mermaid renders on GitHub (verified during composition)
- [x] Doc-only change; no code or tests touched