### PR TITLE
feat: persist AUTO state machine + command-desync detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,10 +488,41 @@ Conditions checked:
 | `real_climate_unavailable` / `_missing` | Wrapped climate device is unreachable | immediate |
 | `out_of_band:Nmin` | AUTO can't keep room in band | `OUT_OF_BAND_ALERT_MINUTES` (30) |
 | `short_cycle:N/h` | COOL starts/hour too high | `SHORT_CYCLE_THRESHOLD_PER_H` (6) |
+| `command_desync:want=X_got=Y` | Wrapper commanded `X` but real device is in `Y` past `COMMAND_GRACE_SECONDS` (60) | 60 s |
 
 `out_of_band` only fires in AUTO (manual modes are on the user's
 terms).  `short_cycle` count is a rolling 1-hour window of `OFF→COOL`
 transitions tracked in `_async_sync_real_climate`.
+
+**`command_desync`** catches silent failure to land a command — e.g.
+a `set_hvac_mode` call dropped during a real-device unavailability,
+or the real device deciding for itself.  Only the *change* of
+`_unit_command` resets the grace window; re-issuing the same command
+does not.
+
+### State-machine persistence
+
+The wrapper persists two pieces of state-machine state across HA
+restarts via `extra_state_attributes` (which `RestoreEntity`
+serialises automatically):
+
+- `auto_mode_committed` — the sticky direction (`heat`/`cool`).
+- `last_unit_command` — the wrapper's last commanded mode
+  (`heat`/`cool`/`off`).
+
+`async_added_to_hass` reads both back and rehydrates `_auto_mode`
+and `_unit_command`.  Without persistence, every HA restart re-ran
+the **initial pick** — and on 2026-04-26 the Z-Wave aggregator
+behind `sensor.whole_home_temperature` briefly reported 21.66 °C
+during sensor re-initialisation, committing the wrapper to HEAT for
+30 minutes (until `FLIP_DWELL`) of wrong-direction heating against
+a room that was actually at 22.7 °C.  Persisted state means we keep
+the previously-correct commitment instead of guessing again.
+
+`_pending_flip_since`, `_out_of_band_since`, and `_cool_start_times`
+are *not* persisted — they re-arm naturally from sensor data and
+the worst-case latency on each is acceptable (`FLIP_DWELL` 30 min,
+`OUT_OF_BAND_ALERT_MINUTES` 30 min, short-cycle 1 h window).
 
 `hvac_action` returns `IDLE` (not `OFF`) on the wrapper whenever
 the unit_command is OFF — distinguishes "AUTO resting" from

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -45,6 +45,7 @@ from .const import (
     CONF_REAL_CLIMATE,
     CONF_SLEEP_MAX,
     CONF_SLEEP_MIN,
+    COMMAND_GRACE_SECONDS,
     COOL_RESTART_OFFSET,
     DEFAULT_AWAY_MAX,
     DEFAULT_AWAY_MIN,
@@ -176,6 +177,12 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # frontend distinguishes "AUTO resting" from "user turned it off".
         self._unit_command: HVACMode | None = None
 
+        # Timestamp of the last `_unit_command` change.  Used by the
+        # desync detector to allow the real device a grace period to
+        # transition into the commanded state.  Don't update this on
+        # every sync — only when the command itself changes.
+        self._unit_command_at: datetime.datetime | None = None
+
         # Problem-detection state (surfaced via `problems` attribute).
         # Updated by sensor / sync callbacks; checked at attribute read.
         self._out_of_band_since: datetime.datetime | None = None
@@ -290,13 +297,28 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Surface diagnostic attributes alongside HA's standard ones.
+        """Surface diagnostic + persisted state alongside HA's standard ones.
 
-        ``problems`` is a list of detected issues (empty when healthy).
-        Useful for dashboards and templates: e.g. trigger a notification
-        when ``state_attr('climate.smart_climate', 'problems') | length > 0``.
+        - ``problems`` is a list of detected issues (empty when healthy).
+        - ``auto_mode_committed`` is the sticky direction (`heat`/`cool`)
+          the wrapper has chosen in AUTO mode.  Persisted via RestoreEntity
+          so it survives HA restarts; the wrapper restores it in
+          `async_added_to_hass` to skip the initial pick on potentially
+          glitchy post-restart sensor data.
+        - ``last_unit_command`` is the wrapper's last command to the
+          real device (`heat`/`cool`/`off`).  Persisted for the same
+          reason — keeps COOL hysteresis state continuous across
+          restarts.
         """
-        return {"problems": self._detect_problems()}
+        return {
+            "problems": self._detect_problems(),
+            "auto_mode_committed": (
+                self._auto_mode.value if self._auto_mode else None
+            ),
+            "last_unit_command": (
+                self._unit_command.value if self._unit_command else None
+            ),
+        }
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -329,6 +351,27 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
                 self._target_temp_high = float(attrs[ATTR_TARGET_TEMP_HIGH])
             if ATTR_TEMPERATURE in attrs and attrs[ATTR_TEMPERATURE] is not None:
                 self._target_temperature = float(attrs[ATTR_TEMPERATURE])
+
+            # Restore the AUTO state machine: the sticky committed
+            # direction and the last unit command.  Without this, every
+            # HA restart re-runs the initial pick — and on 2026-04-26
+            # that picked HEAT against a glitchy startup sensor reading
+            # (Z-Wave aggregator briefly reported 21.66 °C while
+            # sensors were re-initialising), committing the wrapper to
+            # 30 minutes of wrong-direction heating.  Persisting these
+            # across restarts keeps the state machine stable.
+            committed = attrs.get("auto_mode_committed")
+            if committed:
+                try:
+                    self._auto_mode = HVACMode(committed)
+                except ValueError:
+                    self._auto_mode = None
+            last_cmd = attrs.get("last_unit_command")
+            if last_cmd:
+                try:
+                    self._unit_command = HVACMode(last_cmd)
+                except ValueError:
+                    self._unit_command = None
 
         # Populate initial state from current entity states
         self._sync_from_real_climate()
@@ -576,6 +619,30 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         if recent > SHORT_CYCLE_THRESHOLD_PER_H:
             problems.append(f"short_cycle:{recent}/h")
 
+        # Command desync.  We track the wrapper's last commanded state
+        # (`_unit_command`) and the timestamp of the last *change*.  If
+        # more than COMMAND_GRACE_SECONDS have passed since the change
+        # AND the real device's state still doesn't match what the
+        # wrapper believes it commanded, surface that — silently
+        # diverging state is the failure mode that produced the
+        # 2026-04-26 ghost-HEAT incident.  We compare against
+        # `_unit_command.value` (e.g. "cool") which is what the real
+        # device's state should read.  The check skips when the real
+        # device is unavailable (already covered by another problem
+        # code) or when no command has been sent yet.
+        if (
+            self._unit_command is not None
+            and self._unit_command_at is not None
+            and real_state is not None
+            and real_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN, None, "")
+        ):
+            elapsed = (now - self._unit_command_at).total_seconds()
+            if elapsed > COMMAND_GRACE_SECONDS:
+                expected = self._unit_command.value
+                actual = real_state.state
+                if expected != actual:
+                    problems.append(f"command_desync:want={expected}_got={actual}")
+
         return problems
 
     def _desired_real_mode(self) -> HVACMode:
@@ -736,6 +803,11 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             and self._unit_command != HVACMode.COOL
         ):
             self._cool_start_times.append(self._now())
+        # Track command changes for desync detection (only when the
+        # command actually changes — re-issuing the same command
+        # shouldn't reset the grace window).
+        if real_mode != self._unit_command:
+            self._unit_command_at = self._now()
         # Record the wrapper's intent so hvac_action can surface IDLE for
         # deliberate-OFF (AUTO + OFF inside the comfort band) without
         # re-running _desired_real_mode (which has timer side-effects).

--- a/custom_components/smart_climate/const.py
+++ b/custom_components/smart_climate/const.py
@@ -71,3 +71,11 @@ COOL_RESTART_OFFSET = 0.75
 OUT_OF_BAND_ALERT_MINUTES   = 30   # sustained outside [low, high] in AUTO
 SHORT_CYCLE_THRESHOLD_PER_H = 6    # COOL starts/hour above this is "too much"
 SENSOR_STALE_MINUTES        = 15   # no inside-temp update for this long
+
+# Command-desync detection: how long we wait for the real device to
+# settle into the wrapper's last commanded state before flagging the
+# divergence as a problem.  60 s is generous — `set_hvac_mode` is
+# fire-and-forget (`blocking=False`), and the real device's
+# soft-start ramp + state-event propagation takes a few seconds even
+# in the happy path.
+COMMAND_GRACE_SECONDS       = 60

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1539,8 +1539,11 @@ class TestProblemDetection:
     def test_healthy_returns_empty_list(self):
         entity, _, _ = self._entity()
         assert entity._detect_problems() == []
-        # And the public attribute echoes the same.
-        assert entity.extra_state_attributes == {"problems": []}
+        # The attribute dict includes problems plus persisted state machine.
+        attrs = entity.extra_state_attributes
+        assert attrs["problems"] == []
+        assert "auto_mode_committed" in attrs
+        assert "last_unit_command" in attrs
 
     def test_inside_sensor_unavailable(self):
         entity, sensor, _ = self._entity(inside_state_value="unavailable")
@@ -1643,6 +1646,57 @@ class TestProblemDetection:
         assert any(p.startswith("inside_sensor_") for p in problems)
         assert "real_climate_unavailable" in problems
 
+    def test_command_desync_within_grace_not_reported(self):
+        """Command just sent — real device hasn't transitioned yet but
+        we're inside the grace window.  No alert."""
+        entity, _, real = self._entity()
+        real.state = "off"  # real device says off
+        entity._unit_command = HVACMode.COOL  # wrapper just commanded cool
+        # 30 seconds ago — within COMMAND_GRACE_SECONDS (60)
+        entity._unit_command_at = entity._now() - datetime.timedelta(seconds=30)
+        assert all(not p.startswith("command_desync") for p in entity._detect_problems())
+
+    def test_command_desync_past_grace_reports(self):
+        """Real device hasn't matched the command after grace window —
+        flag as desync.  Reproduces the 2026-04-26 ghost-HEAT pattern
+        where the wrapper believed it commanded COOL but real device
+        sat in HEAT."""
+        entity, _, real = self._entity()
+        real.state = "heat"
+        entity._unit_command = HVACMode.COOL
+        # Two minutes ago — well past 60s grace
+        entity._unit_command_at = entity._now() - datetime.timedelta(minutes=2)
+        problems = entity._detect_problems()
+        assert any(
+            p == "command_desync:want=cool_got=heat" for p in problems
+        ), problems
+
+    def test_command_desync_real_unavailable_not_reported(self):
+        """Real device unavailable: don't flag desync (already covered
+        by `real_climate_unavailable` and not actionable as desync)."""
+        entity, _, real = self._entity()
+        real.state = "unavailable"
+        entity._unit_command = HVACMode.COOL
+        entity._unit_command_at = entity._now() - datetime.timedelta(minutes=2)
+        assert all(not p.startswith("command_desync") for p in entity._detect_problems())
+
+    def test_command_desync_no_command_yet_not_reported(self):
+        """Wrapper has never sent a command (`_unit_command_at is None`)
+        — no desync to report."""
+        entity, _, real = self._entity()
+        real.state = "heat"
+        entity._unit_command = None
+        entity._unit_command_at = None
+        assert all(not p.startswith("command_desync") for p in entity._detect_problems())
+
+    def test_command_desync_match_not_reported(self):
+        """Real device matches command: no desync."""
+        entity, _, real = self._entity()
+        real.state = "cool"
+        entity._unit_command = HVACMode.COOL
+        entity._unit_command_at = entity._now() - datetime.timedelta(minutes=5)
+        assert all(not p.startswith("command_desync") for p in entity._detect_problems())
+
 
 # ---------------------------------------------------------------------------
 # Unit tests – state restoration on startup
@@ -1658,6 +1712,8 @@ class TestStateRestoration:
         target_temp_low: float = DEFAULT_SLEEP_MIN,
         target_temp_high: float = DEFAULT_SLEEP_MAX,
         temperature: float | None = None,
+        auto_mode_committed: str | None = None,
+        last_unit_command: str | None = None,
     ) -> MagicMock:
         """Build a mock last_state object mimicking HA's RestoreEntity."""
         state = MagicMock()
@@ -1669,6 +1725,10 @@ class TestStateRestoration:
         }
         if temperature is not None:
             attrs["temperature"] = temperature
+        if auto_mode_committed is not None:
+            attrs["auto_mode_committed"] = auto_mode_committed
+        if last_unit_command is not None:
+            attrs["last_unit_command"] = last_unit_command
         state.attributes = attrs
         return state
 
@@ -1822,3 +1882,81 @@ class TestStateRestoration:
             real_climate_temp=25.0,  # wildly divergent setpoint
         )
         assert entity._preset_mode == PRESET_SLEEP
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_committed_restored(self):
+        """`_auto_mode` is restored from last_state.attributes — without
+        this, every HA restart re-runs the initial pick on potentially
+        glitchy post-restart sensor data (the 2026-04-26 ghost-HEAT bug).
+        """
+        last_state = self._make_last_state(
+            hvac_mode=HVACMode.AUTO.value,
+            auto_mode_committed=HVACMode.COOL.value,
+        )
+        entity, _ = await self._setup_entity(last_state, inside_temp=22.5)
+        assert entity._auto_mode == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_last_unit_command_restored(self):
+        """COOL hysteresis state survives restarts: if we were mid-pull
+        (last command COOL), restoration keeps that so the hysteresis
+        doesn't restart from the OFF state."""
+        last_state = self._make_last_state(
+            hvac_mode=HVACMode.AUTO.value,
+            auto_mode_committed=HVACMode.COOL.value,
+            last_unit_command=HVACMode.COOL.value,
+        )
+        entity, _ = await self._setup_entity(last_state, inside_temp=22.3)
+        assert entity._unit_command == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_no_initial_pick_when_committed_restored(self):
+        """When `_auto_mode` is restored, the wrapper must not run the
+        initial-pick logic against current sensor data — the whole
+        point of persistence is to skip that step.
+
+        Set up a scenario that would be a *bad* initial pick (inside
+        21.5, mid 22.5 → would pick HEAT) but with restored COOL.  The
+        wrapper should keep COOL.
+        """
+        last_state = self._make_last_state(
+            hvac_mode=HVACMode.AUTO.value,
+            preset_mode=PRESET_HOME,
+            target_temp_low=DEFAULT_HOME_MIN,
+            target_temp_high=DEFAULT_HOME_MAX,
+            auto_mode_committed=HVACMode.COOL.value,
+        )
+        # inside well below mid — would have picked HEAT if uninitialised.
+        entity, _ = await self._setup_entity(
+            last_state, inside_temp=DEFAULT_HOME_MIN + 0.5
+        )
+        assert entity._auto_mode == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_invalid_committed_value_falls_back_to_none(self):
+        """A garbage `auto_mode_committed` (e.g. an old version's value
+        format) must not crash — fall back to None and the wrapper will
+        do an initial pick on the next sensor tick."""
+        last_state = self._make_last_state(
+            hvac_mode=HVACMode.AUTO.value,
+            auto_mode_committed="garbage",
+        )
+        entity, _ = await self._setup_entity(last_state, inside_temp=22.5)
+        assert entity._auto_mode in (None, HVACMode.HEAT, HVACMode.COOL)
+        # Specifically: it MUST NOT be the literal "garbage" string.
+        assert entity._auto_mode != "garbage"
+
+    @pytest.mark.asyncio
+    async def test_extra_attrs_round_trip(self):
+        """Round-trip: save → restore → save should preserve values.
+        Pins the contract that `extra_state_attributes` keys match what
+        `async_added_to_hass` reads."""
+        last_state = self._make_last_state(
+            hvac_mode=HVACMode.AUTO.value,
+            auto_mode_committed=HVACMode.COOL.value,
+            last_unit_command=HVACMode.OFF.value,
+        )
+        entity, _ = await self._setup_entity(last_state)
+        attrs = entity.extra_state_attributes
+        assert attrs["auto_mode_committed"] == HVACMode.COOL.value
+        assert attrs["last_unit_command"] == HVACMode.OFF.value


### PR DESCRIPTION
## Summary

Two related fixes for the **2026-04-26 ghost-HEAT incident**:

> *"the restart move the real climate to heat as the current temp was 22.7"*

### Root cause analysis

You restarted HA around 15:40.  During startup, Z-Wave sensors take time to come back online.  `sensor.whole_home_temperature` (a Min/Max/Mean helper aggregating Z-Wave-only sensors) briefly reported **21.66 °C** at 15:40:08 while inputs were re-initialising — and 9 readings spread between 22.6 and 23.19 °C in *the same second* at 15:40:19.

The wrapper''s `_auto_mode` was reset to `None` on init (entity recreation).  Its first sensor tick saw `21.66 < mid (22)` → committed **HEAT**.  Once HEAT was committed, the wrapper kept sending HEAT to the real device for 30 minutes (until `FLIP_DWELL` would have flipped it) against a room actually at 22.7 °C.

The PR #62 initial-pick fix (drop outside sensor) was correct in steady state but trusts the inside sensor blindly at the *moment when it''s least reliable* — restart.

## Fix 1: persist the AUTO state machine

The wrapper now persists `_auto_mode` and `_unit_command` across HA restarts via `extra_state_attributes` (which `RestoreEntity` serialises automatically).  After a restart, the wrapper rehydrates from `last_state.attributes` instead of running the initial pick on potentially-glitchy sensor data.

New persisted attributes (visible on the wrapper entity):
- `auto_mode_committed` — `"heat"` / `"cool"` / `null`
- `last_unit_command` — `"heat"` / `"cool"` / `"off"` / `null`

The initial-pick logic still runs **only when `_auto_mode is None` after restoration** — true on first install, false on restart with healthy state.  Invalid / corrupt restored values fall back to `None` gracefully.

`_pending_flip_since`, `_out_of_band_since`, and `_cool_start_times` are *not* persisted — they re-arm naturally from sensor data and worst-case latency on each is acceptable.

## Fix 2: command-desync detection

New `problems` code: `command_desync:want=X_got=Y`.  Per your direct ask:

> *"It should be a problem that we think we send off or cool or heat and the device is not in the state that we think it should be"*

Track timestamp of the last `_unit_command` change.  If the real device''s state hasn''t matched the wrapper''s expectation after `COMMAND_GRACE_SECONDS` (default 60 s), surface in `problems`.

Catches silent failure modes: `set_hvac_mode` dropped during a real-device `unavailable`, the unit deciding for itself (e.g. its own AUTO logic when wrapper accidentally sends `auto`), external automations changing modes behind the wrapper''s back.

## Tests (113 pass)

**State restoration** (5 new in `TestStateRestoration`):
- `_auto_mode` restored from `auto_mode_committed`
- `_unit_command` restored from `last_unit_command`
- Restored commit prevents initial-pick from firing
- Invalid value falls back to `None`
- Round-trip: save → restore → save preserves values

**Desync detection** (5 new in `TestProblemDetection`):
- Within grace → no alert
- Past grace + mismatch → `command_desync:want=cool_got=heat`
- Real device unavailable → no alert (covered by `real_climate_unavailable`)
- No command yet → no alert
- Match → no alert

## Test plan

- [x] `pytest tests/test_climate.py` — 113 green
- [ ] Deploy to live HA at duvall.calvonet.com
- [ ] Verify `auto_mode_committed` and `last_unit_command` show up in the wrapper''s attributes
- [ ] Restart HA: confirm wrapper''s `_auto_mode` survives (no spurious initial pick)
- [ ] Manually flip the real device to a different mode while wrapper is committed: confirm `command_desync:...` appears in `problems` after ~60 s

## Sequence with PR #66 (docs)

This PR is independent of #66 (state-machine diagrams).  Either order is fine; both touch different files.