### PR TITLE
feat!: asymmetric setpoints — HEAT to low, COOL to high (intermediate band)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,23 +108,32 @@ The wrapper picks HEAT or COOL **once** per AUTO entry and holds it.  The
 real device's setpoint is **asymmetric** by direction (since v3.3.0):
 
 - **HEAT** sends `setpoint = low` (e.g. 21 for the [21, 23] preset).
-- **COOL** sends `setpoint = high - 1` (e.g. 22 for the [21, 23] preset).
+- **COOL** sends `setpoint = high` (e.g. 23 for the [21, 23] preset).
 
 The Midea unit's own ±0.5 °C internal hysteresis around setpoint then
 keeps the room near the band edge that matches the committed direction:
 
 - HEAT setpoint=21 → unit holds room around `[21, 21.5]`.
-- COOL setpoint=22 → unit holds room around `[21.5, 22]`.
+- COOL setpoint=23 → unit holds room around `[22.5, 23]`.
 
-This biases each direction toward "minimum effort to keep the room in
-band": HEAT sustains the floor, COOL sustains a level just below mid.
+This creates a symmetric **intermediate band** of `[mid - 0.5, mid + 0.5]`
+(e.g. 21.5 to 22.5 for the [21, 23] preset) where neither mode actively
+pumps — the unit handles the deadband itself via its own setpoint logic.
+
 v2.0.0 / v3.0.x targeted the midpoint (22) for both directions; on this
 unit that produced active heating of comfortable rooms (the v3.1.x
 ghost-HEAT pattern, where HEAT setpoint=22 + current=21.4 caused 64-min
-HEAT pulses to push the room from 21.4 to ~22).  Asymmetric setpoints
-make the unit's own setpoint logic a defense-in-depth: even if the
-wrapper commits HEAT incorrectly, the unit won't actively pump heat
-unless the room is genuinely below the floor.
+HEAT pulses to push the room from 21.4 to ~22).  Asymmetric band-edge
+setpoints make the unit's own setpoint logic a defense-in-depth: even
+if the wrapper commits HEAT incorrectly, the unit won't actively pump
+heat unless the room is genuinely below the floor.
+
+The wrapper's existing in-band COOL hysteresis (restart at `mid + 0.75`,
+stop at `mid`) becomes mostly cosmetic with this design — the unit's own
+idle at `high - 0.5` prevents the room from ever naturally reaching
+`mid`, so the wrapper's OFF-command branch rarely fires.  Left in place
+as a safety net; may be revisited once live data confirms it's
+unreachable in practice.
 
 1. **Initial pick** (when no committed mode yet, e.g. AUTO entered fresh
    or after HA restart):
@@ -155,7 +164,7 @@ Four presets supported (Home Assistant standard):
 - `PRESET_AWAY`: Unoccupied (18–26 °C default)
 - `PRESET_NONE`: Manual mode (no preset enforced)
 
-When preset changes, the entity updates the real device's setpoint per the asymmetric rule (HEAT → low of new preset, COOL → high-1 of new preset).
+When preset changes, the entity updates the real device's setpoint per the asymmetric rule (HEAT → low of new preset, COOL → high of new preset).
 
 ### State Restoration
 
@@ -232,7 +241,7 @@ rm -rf .pytest_cache __pycache__ .coverage
 - Tests are comprehensive — always run them before reporting a task complete
 - Avoid breaking preset or state restoration behavior (very sensitive areas)
 - Temperature calculations must maintain numeric precision (use TEMP_STEP consistently)
-- The real climate device's setpoint in AUTO is asymmetric: `low` for HEAT, `high-1` for COOL (v3.3.0+; was midpoint in v2.0.0–v3.2.x). Critical invariant.
+- The real climate device's setpoint in AUTO is asymmetric: `low` for HEAT, `high` for COOL (v3.3.0+; was midpoint in v2.0.0–v3.2.x). Critical invariant. Combined with the unit's own ±0.5 hysteresis, gives a symmetric `[mid - 0.5, mid + 0.5]` intermediate band.
 - Master/slave (since #43): smart climate is the sole writer of the real device's
   hvac_mode and setpoint; real-device state events are only mirrored as
   `hvac_action` for UI and never feed back into preset/setpoint state

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,12 +104,27 @@ All tests are in `tests/` and must be kept in sync with implementation changes.
 
 ### AUTO Mode Logic — sticky-mode for modulating real devices
 
-The wrapper picks HEAT or COOL **once** per AUTO entry and holds it; the
-real device's setpoint is the comfort-band midpoint (rounded directionally
-to a whole integer — up for HEAT, down for COOL — and clamped into the
-band).  The (modulating) real device is left to settle on the midpoint at
-low compressor modulation rather than being repeatedly start/stop cycled.
-Real device is **never** commanded OFF in AUTO.
+The wrapper picks HEAT or COOL **once** per AUTO entry and holds it.  The
+real device's setpoint is **asymmetric** by direction (since v3.3.0):
+
+- **HEAT** sends `setpoint = low` (e.g. 21 for the [21, 23] preset).
+- **COOL** sends `setpoint = high - 1` (e.g. 22 for the [21, 23] preset).
+
+The Midea unit's own ±0.5 °C internal hysteresis around setpoint then
+keeps the room near the band edge that matches the committed direction:
+
+- HEAT setpoint=21 → unit holds room around `[21, 21.5]`.
+- COOL setpoint=22 → unit holds room around `[21.5, 22]`.
+
+This biases each direction toward "minimum effort to keep the room in
+band": HEAT sustains the floor, COOL sustains a level just below mid.
+v2.0.0 / v3.0.x targeted the midpoint (22) for both directions; on this
+unit that produced active heating of comfortable rooms (the v3.1.x
+ghost-HEAT pattern, where HEAT setpoint=22 + current=21.4 caused 64-min
+HEAT pulses to push the room from 21.4 to ~22).  Asymmetric setpoints
+make the unit's own setpoint logic a defense-in-depth: even if the
+wrapper commits HEAT incorrectly, the unit won't actively pump heat
+unless the room is genuinely below the floor.
 
 1. **Initial pick** (when no committed mode yet, e.g. AUTO entered fresh
    or after HA restart):
@@ -140,7 +155,7 @@ Four presets supported (Home Assistant standard):
 - `PRESET_AWAY`: Unoccupied (18–26 °C default)
 - `PRESET_NONE`: Manual mode (no preset enforced)
 
-When preset changes, the entity updates the real device's setpoint to the preset's midpoint.
+When preset changes, the entity updates the real device's setpoint per the asymmetric rule (HEAT → low of new preset, COOL → high-1 of new preset).
 
 ### State Restoration
 
@@ -217,7 +232,7 @@ rm -rf .pytest_cache __pycache__ .coverage
 - Tests are comprehensive — always run them before reporting a task complete
 - Avoid breaking preset or state restoration behavior (very sensitive areas)
 - Temperature calculations must maintain numeric precision (use TEMP_STEP consistently)
-- The real climate device's setpoint in AUTO is the preset midpoint (critical invariant)
+- The real climate device's setpoint in AUTO is asymmetric: `low` for HEAT, `high-1` for COOL (v3.3.0+; was midpoint in v2.0.0–v3.2.x). Critical invariant.
 - Master/slave (since #43): smart climate is the sole writer of the real device's
   hvac_mode and setpoint; real-device state events are only mirrored as
   `hvac_action` for UI and never feed back into preset/setpoint state

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -835,24 +835,31 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
                 )
             return
 
-        # In AUTO mode, the setpoint sent to the real device is biased
-        # toward the band edge that matches the committed direction —
-        # NOT the band midpoint.  This leverages the unit's own ±0.5 °C
-        # internal hysteresis to keep the room sitting near the edge,
-        # which saves energy and matches occupant comfort better:
+        # In AUTO mode, the setpoint sent to the real device is the
+        # band edge that matches the committed direction — NOT the
+        # midpoint.  Combined with the Midea unit's own ±0.5 °C internal
+        # hysteresis around setpoint, this creates a symmetric
+        # "intermediate band" of `[mid - 0.5, mid + 0.5]` (e.g. 21.5 to
+        # 22.5 for the [21, 23] preset) where neither mode actively
+        # pumps:
         #
-        #   HEAT setpoint = low      → unit holds room at [low, low+0.5]
-        #   COOL setpoint = high - 1 → unit holds room at [high-1.5, high-1]
+        #   HEAT setpoint = low  → unit holds room at [low, low + 0.5]
+        #   COOL setpoint = high → unit holds room at [high - 0.5, high]
         #
         # For default home preset (21-23):
         #   HEAT setpoint=21 → room ~21..21.5
-        #   COOL setpoint=22 → room ~21.5..22
+        #   COOL setpoint=23 → room ~22.5..23
+        #   Intermediate (no active pumping): 21.5 to 22.5
         #
         # The mid-targeting that v2.0.0 used was actively wasteful in
         # sunny PNW climates: HEAT mode at mid=22 would heat a 21.4 °C
         # room to 22 even though 21.4 is well within the comfort band.
         # Diagnosed empirically from 48 h of v3.1.x data showing two
         # 64-min daily HEAT pulses initiated at inside ~21.45 °C.
+        # Asymmetric band-edge setpoints fix this by leveraging the
+        # unit's own setpoint logic as defense in depth: even if the
+        # wrapper commits HEAT incorrectly, the unit refuses to actively
+        # pump heat unless the room is genuinely below the floor.
         low: float | None = None
         high: float | None = None
         if self._hvac_mode == HVACMode.AUTO:
@@ -860,7 +867,7 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             if real_mode == HVACMode.HEAT:
                 target_temp = float(low)
             elif real_mode == HVACMode.COOL:
-                target_temp = float(high) - 1.0
+                target_temp = float(high)
             else:
                 # OFF — value is irrelevant (set_hvac_mode=off path); use
                 # mid as a neutral fallback.

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -835,14 +835,36 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
                 )
             return
 
-        # In AUTO mode, the modulating real device is asked to settle on the
-        # comfort-band midpoint; mode selection (HEAT vs COOL) is what
-        # determines whether the room is being warmed or cooled towards it.
+        # In AUTO mode, the setpoint sent to the real device is biased
+        # toward the band edge that matches the committed direction —
+        # NOT the band midpoint.  This leverages the unit's own ±0.5 °C
+        # internal hysteresis to keep the room sitting near the edge,
+        # which saves energy and matches occupant comfort better:
+        #
+        #   HEAT setpoint = low      → unit holds room at [low, low+0.5]
+        #   COOL setpoint = high - 1 → unit holds room at [high-1.5, high-1]
+        #
+        # For default home preset (21-23):
+        #   HEAT setpoint=21 → room ~21..21.5
+        #   COOL setpoint=22 → room ~21.5..22
+        #
+        # The mid-targeting that v2.0.0 used was actively wasteful in
+        # sunny PNW climates: HEAT mode at mid=22 would heat a 21.4 °C
+        # room to 22 even though 21.4 is well within the comfort band.
+        # Diagnosed empirically from 48 h of v3.1.x data showing two
+        # 64-min daily HEAT pulses initiated at inside ~21.45 °C.
         low: float | None = None
         high: float | None = None
         if self._hvac_mode == HVACMode.AUTO:
             low, high = self._active_range()
-            target_temp = (low + high) / 2.0
+            if real_mode == HVACMode.HEAT:
+                target_temp = float(low)
+            elif real_mode == HVACMode.COOL:
+                target_temp = float(high) - 1.0
+            else:
+                # OFF — value is irrelevant (set_hvac_mode=off path); use
+                # mid as a neutral fallback.
+                target_temp = (low + high) / 2.0
         else:
             target_temp = self._target_temperature
 
@@ -852,11 +874,11 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
         # send — otherwise it silently rounds (e.g. 22.5 → 22) and every
         # inside-sensor update drives another set_temperature call trying to
         # "correct" the mismatch, producing target flutter.
-        # Round directionally (up for HEAT, down for COOL) and stay inside
-        # the comfort band, falling back to the opposite-direction integer
-        # bound when the band is too narrow for the directional rounding to
-        # land inside it (e.g. mid 21.25 in a 21–21.5 band: ceil=22 is
-        # above high → use floor(high)=21 instead).
+        # Round directionally (up for HEAT, down for COOL).  With band-edge
+        # setpoints the rounding usually lands on the integer band edge
+        # itself, but for non-integer bands we still want to stay inside the
+        # comfort band — fall back to the opposite-direction integer bound
+        # when the directional rounding lands outside it.
         if real_mode == HVACMode.HEAT:
             target_temp = float(math.ceil(target_temp))
             if high is not None and target_temp > high:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1234,9 +1234,15 @@ class TestSyncedSetpoints:
     """
 
     @pytest.mark.asyncio
-    async def test_sync_heat_targets_midpoint_rounded_up(self):
-        """HEAT in AUTO: target = ceil(midpoint), within the band."""
-        low, high = 21.0, 24.0  # midpoint 22.5 → ceil = 23
+    async def test_sync_heat_targets_low_edge(self):
+        """HEAT in AUTO: setpoint = low edge of band (NOT midpoint).
+
+        v3.3.0 asymmetric setpoint design.  The unit's own ±0.5 °C
+        hysteresis around setpoint=low keeps the room near low (e.g.
+        21..21.5 for low=21), avoiding active heating of comfortable
+        rooms — the v3.1.x ghost-HEAT pattern.
+        """
+        low, high = 21.0, 24.0  # HEAT setpoint should be low = 21
         hass = _make_hass_mock(
             real_climate_state=HVACMode.HEAT.value,
             real_climate_temp=None,
@@ -1255,14 +1261,20 @@ class TestSyncedSetpoints:
         assert call_args[0][0] == "climate"
         assert call_args[0][1] == "set_temperature"
         sent = call_args[0][2]["temperature"]
-        assert sent == 23
+        assert sent == 21, f"HEAT setpoint should be low (21), got {sent}"
         assert sent == int(sent)
         assert call_args[0][2]["hvac_mode"] == HVACMode.HEAT.value
 
     @pytest.mark.asyncio
-    async def test_sync_cool_targets_midpoint_rounded_down(self):
-        """COOL in AUTO: target = floor(midpoint), within the band."""
-        low, high = 21.0, 24.0  # midpoint 22.5 → floor = 22
+    async def test_sync_cool_targets_high_minus_one(self):
+        """COOL in AUTO: setpoint = high - 1 (NOT midpoint).
+
+        Unit cools toward high-1 with its own ±0.5 hysteresis, keeping
+        the room in the upper half of the band (e.g. 22..23 for
+        high=24).  Less aggressive than mid-targeting; saves energy
+        for wider bands.
+        """
+        low, high = 21.0, 24.0  # COOL setpoint should be high - 1 = 23
         hass = _make_hass_mock(
             real_climate_state=HVACMode.COOL.value,
             real_climate_temp=None,
@@ -1278,12 +1290,12 @@ class TestSyncedSetpoints:
         await entity._async_sync_real_climate()
         call_args = hass.services.async_call.call_args
         sent = call_args[0][2]["temperature"]
-        assert sent == 22
+        assert sent == 23, f"COOL setpoint should be high-1 (23), got {sent}"
         assert sent == int(sent)
 
     @pytest.mark.asyncio
-    async def test_sync_21_23_band_heat_target_is_22(self):
-        """21-23 band: midpoint is 22 (integer), HEAT and COOL both send 22."""
+    async def test_sync_21_23_band_heat_target_is_low(self):
+        """21-23 band: HEAT setpoint = low = 21."""
         low, high = 21.0, 23.0
         hass = _make_hass_mock(
             real_climate_state=HVACMode.HEAT.value,
@@ -1298,10 +1310,12 @@ class TestSyncedSetpoints:
         entity._current_temperature = low - 1
         entity._auto_mode = HVACMode.HEAT
         await entity._async_sync_real_climate()
-        assert hass.services.async_call.call_args[0][2]["temperature"] == 22
+        assert hass.services.async_call.call_args[0][2]["temperature"] == 21
 
     @pytest.mark.asyncio
     async def test_sync_21_23_band_cool_target_is_22(self):
+        """21-23 band: COOL setpoint = high-1 = 22 (coincidentally same
+        as old midpoint-based behavior for this narrow band)."""
         low, high = 21.0, 23.0
         hass = _make_hass_mock(
             real_climate_state=HVACMode.COOL.value,
@@ -1323,10 +1337,10 @@ class TestSyncedSetpoints:
         """When the device's reported setpoint matches what we'd send, no
         service call fires — guards against a per-sensor-update resend
         loop (the integer-rounding fix from #46/#47)."""
-        low, high = 21.0, 23.0  # midpoint 22 (integer)
+        low, high = 21.0, 23.0  # HEAT setpoint = low = 21
         hass = _make_hass_mock(
             real_climate_state=HVACMode.HEAT.value,
-            real_climate_temp=22,  # exactly what we'd send
+            real_climate_temp=21,  # exactly what we'd send (HEAT setpoint = low)
             inside_temp=low - 1,
         )
         entity = _make_entity(hass)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1266,15 +1266,17 @@ class TestSyncedSetpoints:
         assert call_args[0][2]["hvac_mode"] == HVACMode.HEAT.value
 
     @pytest.mark.asyncio
-    async def test_sync_cool_targets_high_minus_one(self):
-        """COOL in AUTO: setpoint = high - 1 (NOT midpoint).
+    async def test_sync_cool_targets_high_edge(self):
+        """COOL in AUTO: setpoint = high (the band's upper edge).
 
-        Unit cools toward high-1 with its own ±0.5 hysteresis, keeping
-        the room in the upper half of the band (e.g. 22..23 for
-        high=24).  Less aggressive than mid-targeting; saves energy
-        for wider bands.
+        Unit cools toward high with its own ±0.5 hysteresis, keeping
+        the room in `[high - 0.5, high]` (e.g. 23.5..24 for high=24).
+        Combined with HEAT setpoint=low, this creates a symmetric
+        intermediate band of `[mid - 0.5, mid + 0.5]` where neither
+        mode actively pumps — the unit handles the deadband itself
+        via setpoint-vs-current.
         """
-        low, high = 21.0, 24.0  # COOL setpoint should be high - 1 = 23
+        low, high = 21.0, 24.0  # COOL setpoint should be high = 24
         hass = _make_hass_mock(
             real_climate_state=HVACMode.COOL.value,
             real_climate_temp=None,
@@ -1290,7 +1292,7 @@ class TestSyncedSetpoints:
         await entity._async_sync_real_climate()
         call_args = hass.services.async_call.call_args
         sent = call_args[0][2]["temperature"]
-        assert sent == 23, f"COOL setpoint should be high-1 (23), got {sent}"
+        assert sent == 24, f"COOL setpoint should be high (24), got {sent}"
         assert sent == int(sent)
 
     @pytest.mark.asyncio
@@ -1313,9 +1315,13 @@ class TestSyncedSetpoints:
         assert hass.services.async_call.call_args[0][2]["temperature"] == 21
 
     @pytest.mark.asyncio
-    async def test_sync_21_23_band_cool_target_is_22(self):
-        """21-23 band: COOL setpoint = high-1 = 22 (coincidentally same
-        as old midpoint-based behavior for this narrow band)."""
+    async def test_sync_21_23_band_cool_target_is_high(self):
+        """21-23 band: COOL setpoint = high = 23.
+
+        Unit's own ±0.5 hysteresis around 23 keeps room at 22.5..23.
+        Combined with HEAT setpoint=low (21) holding 21..21.5, gives a
+        symmetric 21.5..22.5 intermediate band where neither mode pumps.
+        """
         low, high = 21.0, 23.0
         hass = _make_hass_mock(
             real_climate_state=HVACMode.COOL.value,
@@ -1330,7 +1336,7 @@ class TestSyncedSetpoints:
         entity._current_temperature = high + 1
         entity._auto_mode = HVACMode.COOL
         await entity._async_sync_real_climate()
-        assert hass.services.async_call.call_args[0][2]["temperature"] == 22
+        assert hass.services.async_call.call_args[0][2]["temperature"] == 23
 
     @pytest.mark.asyncio
     async def test_sync_no_resend_when_device_holds_target(self):


### PR DESCRIPTION
## Summary

Change the AUTO-mode setpoint sent to the wrapped device from `midpoint` (symmetric) to **asymmetric per direction**, leveraging the unit''s own ±0.5 °C hysteresis to create a symmetric **intermediate band** where neither mode actively pumps:

| Mode | Setpoint | Unit holds room at | For [21, 23] band |
|---|---|---|---|
| HEAT | `low` | `[low, low + 0.5]` | `21 → 22 setpoint` *(was)* → **`21`** *(now)*, room at `[21, 21.5]` |
| COOL | `high` | `[high - 0.5, high]` | `22 → 22 setpoint` *(was)* → **`23`** *(now)*, room at `[22.5, 23]` |
| **Intermediate** | — | `[mid - 0.5, mid + 0.5]` | **`[21.5, 22.5]`** — no active pumping |

## Diagnosis

48 h of v3.1.x recorder data showed the failure mode clearly:

```
04-26 19:42 → cool   (1 cycle, 18 min)
04-27 09:17 → heat   (64 min, started at inside=21.44)
04-28 10:20 → heat   (64 min, started at inside=21.43)
```

Both 64-min HEAT pulses initiated when inside crossed below `mid - FLIP_MARGIN = 21.5` and the dwell-flip fired. With `HEAT setpoint = mid (22)`, the unit saw `current=21.4 < setpoint=22` and **actively pumped heat for an hour to close a 0.6 °C gap** — heating an already-comfortable room.

The wrapper had no in-band hysteresis on the HEAT side (intentional v3.0.0 design), so HEAT-committed always meant active heating until dwell-flip back to COOL.

## Fix

Setpoint=low (HEAT) makes the unit''s own setpoint logic refuse to actively heat unless the room is below the band floor.  Setpoint=high (COOL) similarly refuses to actively cool unless the room is above the band ceiling.  **Defense in depth:** wrapper commits a direction; unit''s setpoint logic decides whether to actively pump.

## Per-preset implications

| Preset | HEAT setpoint | COOL setpoint |
|---|---|---|
| Home `[21, 23]` (this deployment) | 22 → **21** | 22 → **23** |
| Default home `[21, 24]` | 22.5 → **21** | 22.5 → **24** |
| Sleep `[19, 22]` | 20.5 → **19** | 20.5 → **22** |
| Away `[18, 26]` | 22 → **18** | 22 → **26** (huge energy save) |

## Wrapper hysteresis interaction

The wrapper''s in-band COOL hysteresis (restart at `mid + 0.75`, stop at `mid`) becomes mostly cosmetic with this design — the unit''s own idle at `high - 0.5` prevents the room from naturally reaching `mid`, so the wrapper''s OFF-command branch rarely fires.  **Left in place as a safety net**; may be revisited in a future PR once live data confirms it''s unreachable in practice.

## Breaking change

The "real device setpoint == preset midpoint" invariant — documented in CLAUDE.md and pinned by tests — is inverted.  Downstream automations or templates that watched `state_attr(real_climate, "temperature")` for the midpoint need to update.

## Tests (113 pass)

Four `TestSyncedSetpoints` tests rebased:

- `test_sync_heat_targets_midpoint_rounded_up` → `test_sync_heat_targets_low_edge`
- `test_sync_cool_targets_midpoint_rounded_down` → `test_sync_cool_targets_high_edge`
- `test_sync_21_23_band_heat_target_is_22` → `test_sync_21_23_band_heat_target_is_low` (asserts 21)
- `test_sync_21_23_band_cool_target_is_22` → `test_sync_21_23_band_cool_target_is_high` (asserts 23)
- `test_sync_no_resend_when_device_holds_target` updated `real_climate_temp` from 22 to 21

Narrow-band edge-case tests (`test_sync_narrow_band_*`) continue to pass unchanged — new formula naturally lands on band edges.

CLAUDE.md updated to reflect the new contract; the "preset midpoint" critical-invariant note inverted; intermediate band documented.

## Test plan

- [x] `pytest tests/test_climate.py` — 113 green
- [ ] Deploy to live HA at duvall.calvonet.com
- [ ] Watch the next sustained sub-21.5 excursion: should see wrapper command HEAT with setpoint=21 (was 22).  Real unit should idle at room ≥ 21.5 instead of pumping toward 22.
- [ ] On a sunny afternoon: COOL setpoint should be 23 for [21, 23] band.  Real unit should idle at room ≤ 22.5, only actively cool when room > 23.
- [ ] Confirm intermediate band 21.5..22.5: no active pumping, unit idles in either committed direction.
- [ ] Watch for any unexpected wrapper-OFF commands in COOL mode (the legacy hysteresis branch becoming reachable).