### PR TITLE
fix: COOL setpoint back to high - 1 (v4.0.0 setpoint=high pushed room out of band)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,35 +105,48 @@ All tests are in `tests/` and must be kept in sync with implementation changes.
 ### AUTO Mode Logic — sticky-mode for modulating real devices
 
 The wrapper picks HEAT or COOL **once** per AUTO entry and holds it.  The
-real device's setpoint is **asymmetric** by direction (since v3.3.0):
+real device's setpoint is **asymmetric** by direction:
 
 - **HEAT** sends `setpoint = low` (e.g. 21 for the [21, 23] preset).
-- **COOL** sends `setpoint = high` (e.g. 23 for the [21, 23] preset).
+- **COOL** sends `setpoint = high - 1` (e.g. 22 for the [21, 23] preset).
 
-The Midea unit's own ±0.5 °C internal hysteresis around setpoint then
-keeps the room near the band edge that matches the committed direction:
+The Midea unit's actual hysteresis is **asymmetric**: it holds the room
+**at or slightly above setpoint** (~setpoint to setpoint + 0.3-0.5) in
+*both* HEAT and COOL.  Initial design assumed symmetric ±0.5 around
+setpoint; live observation 2026-04-29 corrected this — with COOL
+setpoint=23 the unit held the room at 23.2-23.3, *above* the band high
+edge.  v4.0.0's `setpoint=high` formula was therefore unsafe.
 
-- HEAT setpoint=21 → unit holds room around `[21, 21.5]`.
-- COOL setpoint=23 → unit holds room around `[22.5, 23]`.
+Corrected formulas:
 
-This creates a symmetric **intermediate band** of `[mid - 0.5, mid + 0.5]`
-(e.g. 21.5 to 22.5 for the [21, 23] preset) where neither mode actively
-pumps — the unit handles the deadband itself via its own setpoint logic.
+- HEAT setpoint=low → unit holds room at `[low, low + 0.5]` ≈ `[21, 21.5]`.
+- COOL setpoint=high - 1 → unit holds room at `[high - 1, high - 0.5]` ≈ `[22, 22.5]`.
+
+The asymmetric `+0` for HEAT vs `-1` for COOL is dictated by the unit's
+positive-only overshoot: HEAT `setpoint=low` puts the room at low+ε
+(above floor, OK), but COOL `setpoint=high` would put the room at
+high+ε (above ceiling, NOT OK).  Subtracting 1 °C from COOL leaves
+room for the overshoot to land in band.
+
+This gives an intermediate band around `[mid - 0.5, mid]` (e.g. 21.5 to
+22 for [21, 23]) where neither mode actively pumps — the unit handles
+the deadband via its own setpoint logic.  Narrower than the v4.0.0
+"symmetric intermediate band" target (which assumed symmetric unit
+hysteresis), but actually achievable given the unit's real behavior.
 
 v2.0.0 / v3.0.x targeted the midpoint (22) for both directions; on this
 unit that produced active heating of comfortable rooms (the v3.1.x
 ghost-HEAT pattern, where HEAT setpoint=22 + current=21.4 caused 64-min
-HEAT pulses to push the room from 21.4 to ~22).  Asymmetric band-edge
-setpoints make the unit's own setpoint logic a defense-in-depth: even
-if the wrapper commits HEAT incorrectly, the unit won't actively pump
-heat unless the room is genuinely below the floor.
+HEAT pulses to push the room from 21.4 to ~22).  Band-edge setpoints
+fix this by leveraging the unit's own setpoint logic as defense in
+depth: even if the wrapper commits HEAT incorrectly, the unit won't
+actively pump heat unless the room is genuinely below the floor.
 
 The wrapper's existing in-band COOL hysteresis (restart at `mid + 0.75`,
-stop at `mid`) becomes mostly cosmetic with this design — the unit's own
-idle at `high - 0.5` prevents the room from ever naturally reaching
-`mid`, so the wrapper's OFF-command branch rarely fires.  Left in place
-as a safety net; may be revisited once live data confirms it's
-unreachable in practice.
+stop at `mid`) is still useful as a safety net during transition periods
+where outside cooling is faster than the unit's own dynamics could
+anticipate (see the cold-front transition walkthrough in design
+discussion).
 
 1. **Initial pick** (when no committed mode yet, e.g. AUTO entered fresh
    or after HA restart):
@@ -164,7 +177,7 @@ Four presets supported (Home Assistant standard):
 - `PRESET_AWAY`: Unoccupied (18–26 °C default)
 - `PRESET_NONE`: Manual mode (no preset enforced)
 
-When preset changes, the entity updates the real device's setpoint per the asymmetric rule (HEAT → low of new preset, COOL → high of new preset).
+When preset changes, the entity updates the real device's setpoint per the asymmetric rule (HEAT → low of new preset, COOL → high - 1 of new preset).
 
 ### State Restoration
 
@@ -241,7 +254,7 @@ rm -rf .pytest_cache __pycache__ .coverage
 - Tests are comprehensive — always run them before reporting a task complete
 - Avoid breaking preset or state restoration behavior (very sensitive areas)
 - Temperature calculations must maintain numeric precision (use TEMP_STEP consistently)
-- The real climate device's setpoint in AUTO is asymmetric: `low` for HEAT, `high` for COOL (v3.3.0+; was midpoint in v2.0.0–v3.2.x). Critical invariant. Combined with the unit's own ±0.5 hysteresis, gives a symmetric `[mid - 0.5, mid + 0.5]` intermediate band.
+- The real climate device's setpoint in AUTO is asymmetric: `low` for HEAT, `high - 1` for COOL (corrected from v4.0.0's `high` after live observation showed unit overshoot is positive-only, not symmetric). Critical invariant.
 - Master/slave (since #43): smart climate is the sole writer of the real device's
   hvac_mode and setpoint; real-device state events are only mirrored as
   `hvac_action` for UI and never feed back into preset/setpoint state

--- a/custom_components/smart_climate/climate.py
+++ b/custom_components/smart_climate/climate.py
@@ -835,31 +835,41 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
                 )
             return
 
-        # In AUTO mode, the setpoint sent to the real device is the
-        # band edge that matches the committed direction — NOT the
-        # midpoint.  Combined with the Midea unit's own ±0.5 °C internal
-        # hysteresis around setpoint, this creates a symmetric
-        # "intermediate band" of `[mid - 0.5, mid + 0.5]` (e.g. 21.5 to
-        # 22.5 for the [21, 23] preset) where neither mode actively
-        # pumps:
+        # In AUTO mode, the setpoint sent to the real device is biased
+        # toward the band edge that matches the committed direction —
+        # NOT the band midpoint, NOT the band edge itself.  The Midea
+        # unit's actual hysteresis is asymmetric: it holds the room
+        # **at or slightly above setpoint** in BOTH modes (~setpoint to
+        # setpoint + 0.3-0.5).  Live observation 2026-04-29 with COOL
+        # setpoint=23 showed room sitting at 23.2-23.3 — *above* the
+        # band high edge (23).  v4.0.0's `setpoint=high` formula was
+        # therefore wrong: it pushed the room out of the comfort band.
         #
-        #   HEAT setpoint = low  → unit holds room at [low, low + 0.5]
-        #   COOL setpoint = high → unit holds room at [high - 0.5, high]
+        # Corrected formulas (since v4.0.x):
+        #
+        #   HEAT setpoint = low      → unit holds room at [low, low+0.5]
+        #   COOL setpoint = high - 1 → unit holds room at [high-1, high-0.5]
         #
         # For default home preset (21-23):
-        #   HEAT setpoint=21 → room ~21..21.5
-        #   COOL setpoint=23 → room ~22.5..23
-        #   Intermediate (no active pumping): 21.5 to 22.5
+        #   HEAT setpoint=21 → room ~21..21.5  (in band, near low)
+        #   COOL setpoint=22 → room ~22..22.5  (in band, mid)
+        #   Intermediate band (no active pumping): 21.5..22
+        #
+        # Why "-1" for COOL but "+0" for HEAT: the unit's overshoot is
+        # always positive (above setpoint), so HEAT setpoint=low gives
+        # room at low+ε (above floor, OK) while COOL setpoint=high
+        # would give room at high+ε (above ceiling, NOT OK).  Subtract
+        # 1 °C from COOL's setpoint to leave room for the overshoot.
         #
         # The mid-targeting that v2.0.0 used was actively wasteful in
         # sunny PNW climates: HEAT mode at mid=22 would heat a 21.4 °C
         # room to 22 even though 21.4 is well within the comfort band.
         # Diagnosed empirically from 48 h of v3.1.x data showing two
         # 64-min daily HEAT pulses initiated at inside ~21.45 °C.
-        # Asymmetric band-edge setpoints fix this by leveraging the
-        # unit's own setpoint logic as defense in depth: even if the
-        # wrapper commits HEAT incorrectly, the unit refuses to actively
-        # pump heat unless the room is genuinely below the floor.
+        # Band-edge setpoints fix this by leveraging the unit's own
+        # setpoint logic as defense in depth: even if the wrapper
+        # commits HEAT incorrectly, the unit refuses to actively pump
+        # heat unless the room is genuinely below the floor.
         low: float | None = None
         high: float | None = None
         if self._hvac_mode == HVACMode.AUTO:
@@ -867,7 +877,7 @@ class SmartClimateEntity(ClimateEntity, RestoreEntity):
             if real_mode == HVACMode.HEAT:
                 target_temp = float(low)
             elif real_mode == HVACMode.COOL:
-                target_temp = float(high)
+                target_temp = float(high) - 1.0
             else:
                 # OFF — value is irrelevant (set_hvac_mode=off path); use
                 # mid as a neutral fallback.

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1266,17 +1266,17 @@ class TestSyncedSetpoints:
         assert call_args[0][2]["hvac_mode"] == HVACMode.HEAT.value
 
     @pytest.mark.asyncio
-    async def test_sync_cool_targets_high_edge(self):
-        """COOL in AUTO: setpoint = high (the band's upper edge).
+    async def test_sync_cool_targets_high_minus_one(self):
+        """COOL in AUTO: setpoint = high - 1 (one below the band ceiling).
 
-        Unit cools toward high with its own ±0.5 hysteresis, keeping
-        the room in `[high - 0.5, high]` (e.g. 23.5..24 for high=24).
-        Combined with HEAT setpoint=low, this creates a symmetric
-        intermediate band of `[mid - 0.5, mid + 0.5]` where neither
-        mode actively pumps — the unit handles the deadband itself
-        via setpoint-vs-current.
+        v4.0.x corrected the v4.0.0 `setpoint=high` design after live
+        observation 2026-04-29: the Midea unit holds the room at
+        setpoint + 0.2 to 0.5 in COOL (overshoot is positive, NOT
+        symmetric ±0.5 as initially modeled).  With setpoint=23 the
+        room sat at 23.2-23.3 — above the band ceiling.  Subtracting
+        1 °C gives setpoint=22, room at 22.2-22.5, in band.
         """
-        low, high = 21.0, 24.0  # COOL setpoint should be high = 24
+        low, high = 21.0, 24.0  # COOL setpoint should be high - 1 = 23
         hass = _make_hass_mock(
             real_climate_state=HVACMode.COOL.value,
             real_climate_temp=None,
@@ -1292,7 +1292,7 @@ class TestSyncedSetpoints:
         await entity._async_sync_real_climate()
         call_args = hass.services.async_call.call_args
         sent = call_args[0][2]["temperature"]
-        assert sent == 24, f"COOL setpoint should be high (24), got {sent}"
+        assert sent == 23, f"COOL setpoint should be high-1 (23), got {sent}"
         assert sent == int(sent)
 
     @pytest.mark.asyncio
@@ -1315,12 +1315,13 @@ class TestSyncedSetpoints:
         assert hass.services.async_call.call_args[0][2]["temperature"] == 21
 
     @pytest.mark.asyncio
-    async def test_sync_21_23_band_cool_target_is_high(self):
-        """21-23 band: COOL setpoint = high = 23.
+    async def test_sync_21_23_band_cool_target_is_22(self):
+        """21-23 band: COOL setpoint = high - 1 = 22.
 
-        Unit's own ±0.5 hysteresis around 23 keeps room at 22.5..23.
-        Combined with HEAT setpoint=low (21) holding 21..21.5, gives a
-        symmetric 21.5..22.5 intermediate band where neither mode pumps.
+        Unit holds room at setpoint + overshoot ≈ 22.2-22.5, just below
+        the band ceiling (23).  v4.0.0 used `high` (23) but the unit's
+        positive overshoot pushed room to 23.2-23.3 (out of band).
+        Corrected to `high - 1` so the overshoot lands in band.
         """
         low, high = 21.0, 23.0
         hass = _make_hass_mock(
@@ -1336,7 +1337,7 @@ class TestSyncedSetpoints:
         entity._current_temperature = high + 1
         entity._auto_mode = HVACMode.COOL
         await entity._async_sync_real_climate()
-        assert hass.services.async_call.call_args[0][2]["temperature"] == 23
+        assert hass.services.async_call.call_args[0][2]["temperature"] == 22
 
     @pytest.mark.asyncio
     async def test_sync_no_resend_when_device_holds_target(self):


### PR DESCRIPTION
## Summary

**v4.0.0 hot fix.**  Live observation today: with COOL setpoint=23 (v4.0.0''s `high` formula), the Midea unit held the room at **23.2-23.3 °C** — *above* the band high edge (23).  Reverts COOL setpoint to the v3.3.0 formula `high - 1`.

## Diagnosis

v4.0.0''s design assumed the unit''s internal hysteresis was symmetric ±0.5 °C around setpoint:
- HEAT setpoint=21 → unit holds [21, 21.5] (above-setpoint overshoot)
- COOL setpoint=23 → unit *expected* to hold [22.5, 23] (below-setpoint overshoot)

Live data confirms the symmetric model was wrong.  The unit''s overshoot is **positive in both modes** (setpoint to setpoint + 0.3-0.5).  So:
- HEAT setpoint=21 → unit holds [21, 21.5] ✓ (overshoot is upward, lands in band)
- COOL setpoint=23 → unit holds [23.2, 23.5] ✗ (overshoot is upward, lands *above* band)

## Fix

Subtract 1 °C from COOL''s setpoint to leave room for the positive overshoot to land in band:

| Band | HEAT setpoint | COOL setpoint (v4.0.0) | COOL setpoint (this fix) |
|---|---|---|---|
| Home `[21, 23]` | 21 | 23 | **22** |
| Default home `[21, 24]` | 21 | 24 | **23** |
| Sleep `[19, 22]` | 19 | 22 | **21** |
| Away `[18, 26]` | 18 | 26 | **25** |

Effective room ranges with the fix:

- HEAT: room at `[low, low + 0.5]` (above floor, in band)
- COOL: room at `[high - 1, high - 0.5]` (below ceiling, in band)
- Intermediate band: `[low + 0.5, high - 1]` ≈ `[21.5, 22]` for [21, 23]

## Why the asymmetric `+0` for HEAT vs `-1` for COOL

The unit''s overshoot is positive-only.  HEAT''s positive overshoot is *good* (pushes room above floor).  COOL''s positive overshoot is *bad* (pushes room above ceiling).  Subtract 1 °C from COOL only.

## Tests (113 pass)

- `test_sync_cool_targets_high_edge` → `test_sync_cool_targets_high_minus_one` (assertion 24 → 23 for [21, 24])
- `test_sync_21_23_band_cool_target_is_high` → `test_sync_21_23_band_cool_target_is_22` (assertion 23 → 22)

CLAUDE.md updated with the corrected unit-overshoot model.

## Test plan

- [x] `pytest tests/test_climate.py` — 113 green
- [ ] Deploy to live HA at duvall.calvonet.com
- [ ] Confirm next active COOL phase: real device `temperature` should read **22** (was 23 in v4.0.0)
- [ ] Confirm room settles at ~22-22.5 in COOL phase, NOT 23.2-23.3